### PR TITLE
Improve accuracy of accent marking functionality

### DIFF
--- a/api/accent_marker.py
+++ b/api/accent_marker.py
@@ -32,8 +32,9 @@ def clean_query(query):
 
 def is_kana_or_kanji(char):
     """Check whether given character is kana or kanji (ignore half-width kana)"""
-    if char == '\u30a0':
-        # '゠', which should be regard as punchutation
+    exception_symbols = ['\u30a0', '\u30fb', '\u30fc', '\u30fd', '\u30fe', '\u30ff']
+    if char in exception_symbols:
+        # '゠', '・', 'ー', 'ヽ', 'ヾ', 'ヿ' which should be regard as punchutation
         return False
     kana = range(0x3040, 0x30FF + 1)
     kanji = range(0x4E00, 0x9FFF + 1)
@@ -164,6 +165,7 @@ def mark_accent(request: Request) -> dict[str, Any]:
             # Therefore we only reserve the punctuation marks from Yahoo
             if isinstance(furigana_result, SingleWordResultObject) and \
                 any(not is_kana_or_kanji(chr) for chr in yahoo_furigana):
+                print(f"Successfully processing {yahoo_furigana} \t with {yahoo_furigana}")
                 final_response_results.append(
                     SingleWordAccentResultObject(
                         furigana=yahoo_furigana,
@@ -264,6 +266,15 @@ def mark_accent(request: Request) -> dict[str, Any]:
             error=ErrorInfo(
                 code=500,
                 message=f"Connection error: {conn_err}"
+            )
+        )
+    except Exception as e:
+        response = Response(
+            status=500,
+            result=[],
+            error=ErrorInfo(
+                code=500,
+                message=f"Non-usual error occurs: {e}"
             )
         )
     return response.model_dump()


### PR DESCRIPTION
In the previous version, we has two critical issues:
1. Erase punchutations and alphabets from query text before sending it to OJAD.
2. Failed everything behind when a mismatch occurs

To solve these two issues, this version did serveral modifications
1. When processing non-kana and non-kanji characters, we directly add the one returned by Yahoo API (which promise the result must align with query text without any annonying modifications) with accent `-1` into `final_response_results`
2. When mismatch occurs, we ignore the one returned by OJAD until a match occurs. If no match has been found, we ignore current words returned by Yahoo API

We also add several exception handling to return error message correctly.

Although this solution could handle many scenerials, there still some issues need to be solved.
1. When Yahoo API's result and OJAD's result has some mismatch in kana, we shall return a promising result, instead of simply ignore it.
2. When accent generated by OJAD is not quite correct, we may consider some rule-based solutions

I decide to create this PR to let design group can use the latest and less buggy version for development. Which means this shouldn't be the last PR from this branch.