### PR TITLE
fix(usage_query)!: fix wrong return type and wrong return data

### DIFF
--- a/api/usage_query.py
+++ b/api/usage_query.py
@@ -26,9 +26,9 @@ class HeadWordRequest(BaseModel):
 
 
 class IdRequest(BaseModel):
-    """Class representing a request object for ID"""
+    """Class representing a request object for headword ID"""
 
-    id: str = Field(description="The ID of the word")
+    headword_id: str = Field(description="The headword ID of the word")
     site: Literal["NLB", "NLT"] = Field(
         default="NLB",
         description="The site to query, either 'NLB' or 'NLT'. Default is 'NLB'.",
@@ -117,7 +117,7 @@ class IdResponse(BaseModel):
         default=200, description="Status code of response align with RFC 9110"
     )
     result: Optional[IdDetails] = Field(
-        description="Details of the word with the given ID"
+        description="Details of the word with the given headword ID"
     )
     error: Optional[ErrorInfo] = Field(
         default=None,
@@ -150,7 +150,7 @@ def text_type(text: str) -> str | None:
 async def get_headwords(
     request: HeadWordRequest, client: httpx.AsyncClient = Depends(get_http_client)
 ) -> dict[str, Any]:
-    """Get headword_list for the word."""
+    """Get the lists of information of headwords with the given word."""
 
     match text_type(request.word):
         case "yomi":
@@ -259,7 +259,7 @@ async def get_headwords(
 async def get_urls(
     request: HeadWordRequest, client: httpx.AsyncClient = Depends(get_http_client)
 ) -> dict[str, Any]:
-    """Get URL for the word with the given word."""
+    """Get the URLs of words with the given word."""
     response = await get_headwords(request, client)
 
     if response["status"] != 200:
@@ -286,7 +286,7 @@ async def get_urls(
 async def get_id_details(
     request: IdRequest, client: httpx.AsyncClient = Depends(get_http_client)
 ) -> dict[str, Any]:
-    """Get details for the word with the given ID."""
+    """Get the details of the given headword ID."""
 
     async def fetch_data(
         mode: Literal["get", "post"], endpoint: str, target: str = ""
@@ -295,12 +295,12 @@ async def get_id_details(
         match mode:
             case "get":
                 headers = {
-                    "Referer": f"{SITE[request.site]}/headword/{request.id}/",
+                    "Referer": f"{SITE[request.site]}/headword/{request.headword_id}/",
                     "User-Agent": "Mozilla/5.0",
                 }
                 try:
                     response = await client.get(
-                        f"{SITE[request.site]}/{endpoint}/{request.id}/",
+                        f"{SITE[request.site]}/{endpoint}/{request.headword_id}/",
                         headers=headers,
                     )
                 except httpx.TimeoutException:
@@ -318,12 +318,12 @@ async def get_id_details(
             case "post":
                 headers = {
                     "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
-                    "Referer": f"{SITE[request.site]}/headword/{request.id}/",
+                    "Referer": f"{SITE[request.site]}/headword/{request.headword_id}/",
                     "User-Agent": "Mozilla/5.0",
                 }
                 try:
                     response = await client.post(
-                        f"{SITE[request.site]}/{endpoint}/{request.id}/",
+                        f"{SITE[request.site]}/{endpoint}/{request.headword_id}/",
                         headers=headers,
                     )
                 except httpx.TimeoutException:


### PR DESCRIPTION
<!-- 請先閱讀我們手冊的 [How to PR](https://hackmd.io/@sessatakuma/pr_template#How-to-PR) 章節 -->
<!-- 記得修改PR標題成 conventional commit 之標題格式  -->

### 目的
把資料改成正確的類型，修正當fetch到的資料是空lsit時會回傳錯誤的資料

### 方法／實作說明
- 關鍵實作：
  - 把`IdDetails`改成正確的類型
  - 修正字典找不到key時的判斷方式
  - 更新comments和`IdRequest`的parameter
