### PR TITLE
perf(api): make dict_query and sentence_query async using httpx

### DIFF
--- a/api/dict_query.py
+++ b/api/dict_query.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, List, Optional
+from typing import Any
 from urllib.parse import parse_qs, urlparse
 
 import httpx
@@ -13,27 +13,32 @@ from api.dependencies import get_http_client
 class Request(BaseModel):
     word: str = Field(description="The word to query")
 
+
 class Definition(BaseModel):
-    pos: List[str] = Field(description="pos list")
-    meanings: List[str] = Field(description="Meanings of the word")
+    pos: list[str] = Field(description="pos list")
+    meanings: list[str] = Field(description="Meanings of the word")
+
 
 class WordResult(BaseModel):
-    kanji: List[str] = Field(description="Kanji")
-    furigana: List[str] = Field(description="Furigana")
-    definitions: List[Definition] = Field(description="Definitions of the word")
+    kanji: list[str] = Field(description="Kanji")
+    furigana: list[str] = Field(description="Furigana")
+    definitions: list[Definition] = Field(description="Definitions of the word")
     id: int = Field(description="ID")
+
 
 class ErrorInfo(BaseModel):
     code: int = Field(description="Error code (similar to HTTP status)")
     message: str = Field(description="Details of the error")
 
+
 class Response(BaseModel):
     status: int = Field(default=200, description="Status code")
-    result: Optional[List[WordResult]] = Field(default=None, 
-                                               description="List of results")
-    error: Optional[ErrorInfo] = Field(default=None, description="Error details")
+    result: list[WordResult] | None = Field(default=None, description="List of results")
+    error: ErrorInfo | None = Field(default=None, description="Error details")
+
 
 router = APIRouter()
+
 
 # 取得所有符合資料的 url
 async def get_all_url(search_word: str, client: httpx.AsyncClient) -> list[str]:
@@ -53,7 +58,7 @@ async def get_all_url(search_word: str, client: httpx.AsyncClient) -> list[str]:
             if entry_id
             else []
         )
-    
+
     soup = BeautifulSoup(response.text, "html.parser")
     rows = soup.find_all("tr", class_="resrow")
 
@@ -61,9 +66,12 @@ async def get_all_url(search_word: str, client: httpx.AsyncClient) -> list[str]:
     for row in rows:
         inp = row.find("input", {"name": "e"})
         if inp and inp.has_attr("value"):
-            url_list.append(f"https://www.edrdg.org/jmwsgi/entr.py?svc=jmdict&e={inp['value']}")
+            url_list.append(
+                f"https://www.edrdg.org/jmwsgi/entr.py?svc=jmdict&e={inp['value']}"
+            )
 
     return url_list
+
 
 # 根據 url 清單回傳查詢結果
 async def get_dict(url_list: list[str], client: httpx.AsyncClient) -> list[WordResult]:
@@ -72,7 +80,7 @@ async def get_dict(url_list: list[str], client: httpx.AsyncClient) -> list[WordR
         try:
             response = await client.get(url)
             response.encoding = response.charset_encoding or "utf-8"
-        except httpx.RequestError  as e:
+        except httpx.RequestError as e:
             raise RuntimeError(f"Network error: {str(e)}")
 
         soup = BeautifulSoup(response.text, "html.parser")
@@ -83,8 +91,10 @@ async def get_dict(url_list: list[str], client: httpx.AsyncClient) -> list[WordR
 
             definitions: list[Definition] = []
             for sense in soup.select("tr.sense"):
-                pos = [k.get_text(" ", strip=True) 
-                       for k in sense.select("span.pos span.abbr")]
+                pos = [
+                    k.get_text(" ", strip=True)
+                    for k in sense.select("span.pos span.abbr")
+                ]
                 meanings = [
                     k.get_text(" ", strip=True).replace("▶", "").strip()
                     for k in sense.select("span.glossx")
@@ -94,21 +104,21 @@ async def get_dict(url_list: list[str], client: httpx.AsyncClient) -> list[WordR
             jmdict_id = soup.select_one('a[href^="srchres.py"]')
             id = int(jmdict_id.get_text(strip=True)) if jmdict_id else 0
 
-            results.append(WordResult(
-                kanji=kanji,
-                furigana=furigana,
-                definitions=definitions,
-                id=id
-            ))
+            results.append(
+                WordResult(
+                    kanji=kanji, furigana=furigana, definitions=definitions, id=id
+                )
+            )
         except Exception as e:
             raise RuntimeError(f"Parse error: {str(e)}")
 
     return results
 
+
 @router.post("/DictQuery/", tags=["DictionaryQuery"], response_model=Response)
-async def dict_query(request: Request, 
-                     client: httpx.AsyncClient = Depends(get_http_client)
-                     ) -> dict[str, Any]:
+async def dict_query(
+    request: Request, client: httpx.AsyncClient = Depends(get_http_client)
+) -> dict[str, Any]:
     """Query JMdict dictionary for the given word."""
 
     try:
@@ -117,26 +127,21 @@ async def dict_query(request: Request,
             return Response(
                 status=404,
                 result=None,
-                error=ErrorInfo(code=404, message="No results found")
+                error=ErrorInfo(code=404, message="No results found"),
             ).model_dump()
 
         results = await get_dict(url_list, client)
-        return Response(
-            status=200,
-            result=results,
-            error=None
-        ).model_dump()
+        return Response(status=200, result=results, error=None).model_dump()
 
     except RuntimeError as e:
         return Response(
-            status=500,
-            result=None,
-            error=ErrorInfo(code=500, message=str(e))
+            status=500, result=None, error=ErrorInfo(code=500, message=str(e))
         ).model_dump()
 
 
 # Test codes
 if __name__ == "__main__":
+
     async def test() -> None:
         async with httpx.AsyncClient() as client:
             print(await dict_query(Request(word="先生"), client))

--- a/api/sentence_query.py
+++ b/api/sentence_query.py
@@ -1,6 +1,6 @@
 import asyncio
 import re
-from typing import Any, List, Optional
+from typing import Any
 
 import httpx
 from bs4 import BeautifulSoup, Comment
@@ -14,51 +14,54 @@ class Request(BaseModel):
     """Class representing a request object"""
 
     word: str = Field(description="The word to query")
-    id: int = Field(description="The unique ID of a word in JMdict.\n" \
-    "Must be obtained through DictionaryQuery to fetch example sentences.")
+    id: int = Field(
+        description="The unique ID of a word in JMdict.\n"
+        "Must be obtained through DictionaryQuery to fetch example sentences."
+    )
+
 
 class WordSentence(BaseModel):
     jp: str = Field(description="jp sentence")
     en: str = Field(description="en sentence")
 
+
 class WordResult(BaseModel):
     word: str = Field(description="Word")
     id: int = Field(description="ID")
-    sentence: List[WordSentence] = Field(description="A list of sentence")
+    sentence: list[WordSentence] = Field(description="A list of sentence")
+
 
 class Response(BaseModel):
     status: int = Field(default=200, description="Status code")
-    result: Optional[WordResult] = Field(description="Results")
-    error: Optional[str] = Field(default=None, description="Error message if any")
+    result: WordResult | None = Field(description="Results")
+    error: str | None = Field(default=None, description="Error message if any")
 
-router = APIRouter()    
+
+router = APIRouter()
+
 
 # 根據接收到的漢字及ID回傳可能的例句
 @router.post("/SentenceQuery/", tags=["SentenceQuery"], response_model=Response)
-async def sentence_query(request: Request,
-                        client: httpx.AsyncClient = Depends(get_http_client),
-                        ) -> dict[str, Any]:
+async def sentence_query(
+    request: Request,
+    client: httpx.AsyncClient = Depends(get_http_client),
+) -> dict[str, Any]:
     """
     Example sentences from JMdict.
 
     - Uses the provided `word`(kanji or furigana) and `id` from DictionaryQuery.
-    - Returns a list of sentences containing 
+    - Returns a list of sentences containing
     both Japanese text and their English translations.
     """
     url = "https://www.edrdg.org/cgi-bin/wwwjdic/wwwjdic?1E"
-    payload = {
-        "dsrchkey": request.word, 
-        "dicsel": "1" 
-    }
+    payload = {"dsrchkey": request.word, "dicsel": "1"}
 
     try:
         response = await client.post(url, data=payload)
         response.encoding = response.charset_encoding or "utf-8"
     except httpx.RequestError as e:
         return Response(
-            status=500,
-            result=None,
-            error=f"Network error: {str(e)}"
+            status=500, result=None, error=f"Network error: {str(e)}"
         ).model_dump()
 
     try:
@@ -66,7 +69,7 @@ async def sentence_query(request: Request,
 
         sentences = []
         found_block = False
-        for block in soup.select('div[style*=clear]'):
+        for block in soup.select("div[style*=clear]"):
             comments = block.find_all(string=lambda text: isinstance(text, Comment))
             if not any(f"ent_seq={request.id}" in c for c in comments):
                 continue
@@ -77,40 +80,33 @@ async def sentence_query(request: Request,
                 if nxt and nxt.get("size") == "-1":
                     s = nxt.get_text(" ", strip=True)
 
-                    s = re.sub(r'^\(\d+\)\s*', '', s)
-                    jp, en= re.split(r'\t+|\s{2,}', s, maxsplit=1)
-                    jp = jp.replace(" ","")
+                    s = re.sub(r"^\(\d+\)\s*", "", s)
+                    jp, en = re.split(r"\t+|\s{2,}", s, maxsplit=1)
+                    jp = jp.replace(" ", "")
 
                     sentences.append(WordSentence(jp=jp.strip(), en=en.strip()))
-        
+
         if not found_block or not sentences:
             return Response(
-                status=404,
-                result=None,
-                error="No results found"
+                status=404, result=None, error="No results found"
             ).model_dump()
 
         return Response(
             status=200,
-            result=WordResult(
-                word=request.word,
-                id=request.id,
-                sentence=sentences
-            ),
-            error=None
+            result=WordResult(word=request.word, id=request.id, sentence=sentences),
+            error=None,
         ).model_dump()
 
     except Exception as e:
         return Response(
-            status=500,
-            result=None,
-            error=f"Parse error: {str(e)}"
+            status=500, result=None, error=f"Parse error: {str(e)}"
         ).model_dump()
 
 
 # Test codes
 if __name__ == "__main__":
-    async def test()-> None:
+
+    async def test() -> None:
         async with httpx.AsyncClient() as client:
             print(await sentence_query(Request(word="先生", id=1387990), client))
             print(await sentence_query(Request(word="せんせい", id=1387990), client))


### PR DESCRIPTION
### 目的
利用 httpx 處理 sentence_query.py 和 dict_query.py 的 async 問題，並使其符合 mypy 及 ruff 的規範

### 方法／實作說明
- 主要修改：
  - `dict_query.py` 
  - `sentence_query.py` 
- 關鍵實作：
  - 利用 httpx 將其改寫為 async 函式
  - 將程式碼符合 mypy 及 ruff 的規範

### 關聯 Issue
Fixes [#11](https://github.com/sessatakuma/API-tools/issues/11)