### PR TITLE
fix: let model can output numeric's furigana

### DIFF
--- a/api/accent_marker.py
+++ b/api/accent_marker.py
@@ -255,7 +255,7 @@ async def mark_accent(
 
         furigana_response = await mark_furigana(Request(text=query_text), client)
 
-        # 檢查 Yahoo 回傳
+        # Check yahoo furigana response
         if furigana_response.status != 200 or not furigana_response.result:
             logger.warning(f"Yahoo Response Empty or Invalid: {furigana_response}")
             return Response(
@@ -285,10 +285,13 @@ async def mark_accent(
                 f"Processing Yahoo Word [{i}]: {yahoo_surface} ({yahoo_furigana})"
             )
 
-            # If query sub-text contains non-kana and non-kanji words, ignore it
+            # Identify if the word is numeric
+            is_numeric = yahoo_surface.isdigit()
+            
+            # ignore non-kana/kanji and non-numeric words
             if not furigana_result.subword and any(
                 not is_kana_or_kanji(chr) for chr in yahoo_furigana
-            ):
+            ) and not is_numeric:
                 logger.debug(" -> Skipped (Not Kana/Kanji)")
                 accents.append(
                     AccentInfo(
@@ -304,70 +307,100 @@ async def mark_accent(
                 )
                 continue
 
-            # Remove all mismatching prefix
+            # Synchronize OJAD index
             ojad_idx = ojad_idx_cnt
 
-            # DEBUG matching logic
-            if ojad_idx < len(ojad_results):
-                ojad_current_hira = jaconv.kata2hira(ojad_results[ojad_idx]["text"])
+            # Check OJAD boundary
+            if ojad_idx >= len(ojad_results):
+                logger.warning(f" -> OJAD Index Out of Bounds ({ojad_idx})")                
+            else:
                 logger.debug(
                     f"-> Comparing Yahoo '{yahoo_furigana_hira}'"
-                    f" vs OJAD '{ojad_current_hira}'"
+                    f" vs OJAD '{ojad_results[ojad_idx]['text']}'"
                 )
-            else:
-                logger.warning(f" -> OJAD Index Out of Bounds ({ojad_idx})")
 
-            while ojad_idx < len(ojad_results) and not yahoo_furigana_hira.startswith(
-                jaconv.kata2hira(ojad_results[ojad_idx]["text"])
-            ):
-                ojad_idx += 1
+            # Move non-numeric OJAD index to the matching position
+            if not is_numeric:
+                while ojad_idx < len(ojad_results) and not yahoo_furigana_hira.startswith(
+                    jaconv.kata2hira(ojad_results[ojad_idx]["text"])
+                ):
+                    ojad_idx += 1
 
             # catch the furigana from Yahoo with OJAD results
             ojad_furigana = ""
             temp_accents = []  # Use temp list to avoid partial data
 
+            # Define anchor(next Yahoo furigana) for numeric mode
+            next_yahoo_furigana = None
+            if i + 1 < len(furigana_results):
+                next_yahoo_furigana = jaconv.kata2hira(furigana_results[i+1].furigana)
+
             # Backup index
             temp_ojad_idx = ojad_idx
+            
+            # Number mode: grab OJAD until the anchor
+            if is_numeric:
+                while temp_ojad_idx < len(ojad_results):
+                    ojad_text = jaconv.kata2hira(ojad_results[temp_ojad_idx]["text"])
 
-            while len(ojad_furigana) < len(yahoo_furigana) and temp_ojad_idx < len(
-                ojad_results
-            ):
-                ojad_text = ojad_results[temp_ojad_idx]["text"]
-                ojad_furigana += ojad_text
-                temp_accents.append(
-                    AccentInfo(
-                        furigana=ojad_text,
-                        accent_marking_type=ojad_results[temp_ojad_idx]["accent"],
-                        length=len(ojad_text),
+                    if next_yahoo_furigana and ojad_text.startswith(next_yahoo_furigana[:1]):
+                        break
+                        
+                    ojad_furigana += ojad_text
+                    temp_accents.append(
+                        AccentInfo(
+                            furigana=ojad_text,
+                            accent_marking_type=ojad_results[temp_ojad_idx]["accent"],
+                            length=len(ojad_text),
+                        )
                     )
-                )
-                temp_ojad_idx += 1
+                    temp_ojad_idx += 1
+            # Normal mode: grab OJAD until length match
+            else:
+                while len(ojad_furigana) < len(yahoo_furigana) and temp_ojad_idx < len(
+                    ojad_results
+                ):
+                    ojad_text = ojad_results[temp_ojad_idx]["text"]
+                    ojad_furigana += ojad_text
+                    temp_accents.append(
+                        AccentInfo(
+                            furigana=ojad_text,
+                            accent_marking_type=ojad_results[temp_ojad_idx]["accent"],
+                            length=len(ojad_text),
+                        )
+                    )
+                    temp_ojad_idx += 1
 
-            # If match success
-            if len(ojad_furigana) == len(yahoo_furigana) and jaconv.kata2hira(
-                ojad_furigana
-            ) == jaconv.kata2hira(yahoo_furigana):
+            # Final matching check
+            is_match = False
+            if is_numeric:
+                # Numeric mode: only check if OJAD has furigana grabbed
+                is_match = len(ojad_furigana) > 0 
+            else:                
+                # Normal mode: check length and content
+                is_match = (len(ojad_furigana) == len(yahoo_furigana) and 
+                            jaconv.kata2hira(ojad_furigana) == jaconv.kata2hira(yahoo_furigana))
+
+            if is_match:
                 logger.debug(f" -> MATCHED! OJAD: {ojad_furigana}")
-                accents.extend(temp_accents)  # Confirm accents
+                accents.extend(temp_accents) 
 
-                # Build accent info list
-
+                # Build final accent info list
                 accent_info_list = []
-                yahoo_furigana_idx = 0
                 for idx, accent in enumerate(accents):
                     accent_info_list.append(
                         AccentInfo(
-                            furigana=yahoo_furigana[
-                                yahoo_furigana_idx : yahoo_furigana_idx + accent.length
-                            ],
+                            furigana=accent.furigana,
                             accent_marking_type=accent.accent_marking_type,
                             length=accent.length,
                         )
                     )
-                    yahoo_furigana_idx += accent.length
 
                 ojad_idx_cnt = temp_ojad_idx  # Update global index
 
+                display_furigana = ojad_furigana if is_numeric else yahoo_furigana
+
+                # Build final response
                 if furigana_result.subword:
                     yahoo_subword = furigana_result.subword
                     logger.debug(
@@ -377,7 +410,7 @@ async def mark_accent(
                     logger.debug(f"[Data Check] yahoo_subword content: {yahoo_subword}")
                     final_response_results.append(
                         WordAccentResult(
-                            furigana=yahoo_furigana,
+                            furigana=display_furigana,
                             surface=yahoo_surface,
                             accent=accent_info_list,
                             subword=[
@@ -389,7 +422,7 @@ async def mark_accent(
                 else:
                     final_response_results.append(
                         WordAccentResult(
-                            furigana=yahoo_furigana,
+                            furigana=display_furigana,
                             surface=yahoo_surface,
                             accent=accent_info_list,
                         )

--- a/api/accent_marker.py
+++ b/api/accent_marker.py
@@ -245,6 +245,216 @@ async def get_ojad_result(
     return paragraph, ojad_results
 
 
+# accept negative integers and decimals
+numeric_pattern = re.compile(r"^-?\d+(\.\d+)?$")
+
+
+async def align_accent(
+    furigana_results: list[Any], ojad_results: list[dict[str, Any]]
+) -> list[WordAccentResult]:
+    """Align yahoo furigana with OJAD results, return final accent marked result"""
+    final_response_results = []
+    ojad_idx_cnt = 0
+
+    logger.debug(f"🔍 [Data Check] First item:{furigana_results[0]}")
+
+    for i, furigana_result in enumerate(furigana_results):
+        yahoo_furigana = furigana_result.furigana
+        yahoo_surface = furigana_result.surface
+
+        yahoo_furigana_hira = jaconv.kata2hira(yahoo_furigana)
+        accents: list[AccentInfo] = []
+
+        logger.debug(f"Processing Yahoo Word [{i}]: {yahoo_surface} ({yahoo_furigana})")
+
+        # Identify if the word is numeric
+        is_numeric = bool(numeric_pattern.match(yahoo_surface))
+
+        # ignore non-kana/kanji and non-numeric words
+        if (
+            not furigana_result.subword
+            and any(not is_kana_or_kanji(chr) for chr in yahoo_furigana)
+            and not is_numeric
+        ):
+            logger.debug(" -> Skipped (Not Kana/Kanji)")
+            accents.append(
+                AccentInfo(
+                    furigana=yahoo_surface,
+                    accent_marking_type=0,
+                    length=len(yahoo_surface),
+                )
+            )
+            final_response_results.append(
+                WordAccentResult(
+                    furigana=yahoo_furigana, surface=yahoo_surface, accent=accents
+                )
+            )
+
+            # Move OJAD index if skipped punctuation
+            if ojad_idx_cnt < len(ojad_results) and jaconv.kata2hira(
+                ojad_results[ojad_idx_cnt]["text"].strip()
+            ) in ["、", "。", ",", "."]:
+                ojad_idx_cnt += 1
+            continue
+
+        # Synchronize OJAD index
+        ojad_idx = ojad_idx_cnt
+
+        # Check OJAD boundary
+        if ojad_idx >= len(ojad_results):
+            logger.warning(f" -> OJAD Index Out of Bounds ({ojad_idx})")
+        else:
+            logger.debug(
+                f"-> Comparing Yahoo '{yahoo_furigana_hira}'"
+                f" vs OJAD '{ojad_results[ojad_idx]['text']}'"
+            )
+
+        # Move non-numeric OJAD index to the matching position
+        if not is_numeric:
+            while ojad_idx < len(ojad_results) and not yahoo_furigana_hira.startswith(
+                jaconv.kata2hira(ojad_results[ojad_idx]["text"])
+            ):
+                ojad_idx += 1
+
+        # catch the furigana from Yahoo with OJAD results
+        ojad_furigana = ""
+        temp_accents = []  # Use temp list to avoid partial data
+
+        # Define anchor(next Yahoo furigana) for numeric mode
+        next_yahoo_furigana = None
+        if i + 1 < len(furigana_results):
+            next_yahoo_furigana = jaconv.kata2hira(furigana_results[i + 1].furigana)
+
+        # Backup index
+        temp_ojad_idx = ojad_idx
+
+        # Number mode: grab OJAD until the anchor
+        if is_numeric:
+            while temp_ojad_idx < len(ojad_results):
+                raw_text = ojad_results[temp_ojad_idx]["text"].strip()
+                ojad_text = jaconv.kata2hira(raw_text)
+
+                # Stop if reached the anchor
+                if next_yahoo_furigana and next_yahoo_furigana.startswith(ojad_text):
+                    break
+
+                # Stop if consumed too much data
+                if len(ojad_furigana) > max(len(yahoo_surface) * 4, 12):
+                    logger.warning(
+                        f" -> Numeric consumption exceeded limit '{yahoo_surface}'."
+                    )
+                    break
+
+                ojad_furigana += ojad_text
+                temp_accents.append(
+                    AccentInfo(
+                        furigana=ojad_text,
+                        accent_marking_type=ojad_results[temp_ojad_idx]["accent"],
+                        length=len(ojad_text),
+                    )
+                )
+                temp_ojad_idx += 1
+        # Normal mode: grab OJAD until length match
+        else:
+            while len(ojad_furigana) < len(yahoo_furigana) and temp_ojad_idx < len(
+                ojad_results
+            ):
+                ojad_text = ojad_results[temp_ojad_idx]["text"]
+                ojad_furigana += ojad_text
+                temp_accents.append(
+                    AccentInfo(
+                        furigana=ojad_text,
+                        accent_marking_type=ojad_results[temp_ojad_idx]["accent"],
+                        length=len(ojad_text),
+                    )
+                )
+                temp_ojad_idx += 1
+
+        # Final matching check
+        is_match = False
+        if is_numeric:
+            # Numeric mode: only check if OJAD has furigana grabbed
+            is_match = len(ojad_furigana) > 0
+        else:
+            # Normal mode: check length and content
+            is_match = len(ojad_furigana) == len(yahoo_furigana) and jaconv.kata2hira(
+                ojad_furigana
+            ) == jaconv.kata2hira(yahoo_furigana)
+
+        if is_match:
+            logger.debug(f" -> MATCHED! OJAD: {ojad_furigana}")
+            accents.extend(temp_accents)
+
+            # Build final accent info list
+            accent_info_list = []
+            for idx, accent in enumerate(accents):
+                accent_info_list.append(
+                    AccentInfo(
+                        furigana=accent.furigana,
+                        accent_marking_type=accent.accent_marking_type,
+                        length=accent.length,
+                    )
+                )
+
+            ojad_idx_cnt = temp_ojad_idx  # Update global index
+
+            display_furigana = ojad_furigana if is_numeric else yahoo_furigana
+
+            # Build final response
+            if furigana_result.subword:
+                yahoo_subword = furigana_result.subword
+                logger.debug(
+                    f"[Type Check] yahoo_subword element type: {type(yahoo_subword[0])}"
+                )
+                logger.debug(f"[Data Check] yahoo_subword content: {yahoo_subword}")
+                final_response_results.append(
+                    WordAccentResult(
+                        furigana=display_furigana,
+                        surface=yahoo_surface,
+                        accent=accent_info_list,
+                        subword=[
+                            WordResult(furigana=s.furigana, surface=s.surface)
+                            for s in yahoo_subword
+                        ],
+                    )
+                )
+            else:
+                final_response_results.append(
+                    WordAccentResult(
+                        furigana=display_furigana,
+                        surface=yahoo_surface,
+                        accent=accent_info_list,
+                    )
+                )
+        else:
+            # [ERROR BLOCK]
+            logger.error(
+                "-> MATCH FAILED."
+                f"Yahoo: {yahoo_furigana} vs OJAD Assembly: {ojad_furigana}"
+            )
+
+            # Fallback to Yahoo furigana with no accent info
+            accent_info = AccentInfo(
+                furigana=yahoo_furigana,
+                accent_marking_type=0,
+                length=len(yahoo_furigana),
+            )
+
+            final_response_results.append(
+                WordAccentResult(
+                    furigana=yahoo_furigana,
+                    surface=yahoo_surface,
+                    accent=[accent_info],
+                )
+            )
+
+            # Move OJAD index to next item to avoid infinite loop
+            if ojad_idx_cnt < len(ojad_results):
+                ojad_idx_cnt += 1
+
+    return final_response_results
+
+
 @router.post("/MarkAccent/", tags=["MarkAccent"], response_model=Response)
 async def mark_accent(
     request: Request, client: httpx.AsyncClient = Depends(get_http_client)
@@ -270,219 +480,9 @@ async def mark_accent(
 
         ojad_surface, ojad_results = await get_ojad_result(query_text, client)
 
-        final_response_results = []
-        ojad_idx_cnt = 0
+        final_results = await align_accent(furigana_results, ojad_results)
 
-        logger.debug(f"🔍 [Data Check] First item:{furigana_results[0]}")
-
-        #accept negative integers and decimals
-        numeric_pattern = re.compile(r"^-?\d+(\.\d+)?$") 
-
-        for i, furigana_result in enumerate(furigana_results):
-            yahoo_furigana = furigana_result.furigana
-            yahoo_surface = furigana_result.surface
-
-            yahoo_furigana_hira = jaconv.kata2hira(yahoo_furigana)
-            accents: list[AccentInfo] = []
-
-            logger.debug(
-                f"Processing Yahoo Word [{i}]: {yahoo_surface} ({yahoo_furigana})"
-            )
-
-            # Identify if the word is numeric
-            is_numeric = bool(numeric_pattern.match(yahoo_surface))
-
-            # ignore non-kana/kanji and non-numeric words
-            if (
-                not furigana_result.subword
-                and any(not is_kana_or_kanji(chr) for chr in yahoo_furigana)
-                and not is_numeric
-            ):
-                logger.debug(" -> Skipped (Not Kana/Kanji)")
-                accents.append(
-                    AccentInfo(
-                        furigana=yahoo_surface,
-                        accent_marking_type=0,
-                        length=len(yahoo_surface),
-                    )
-                )
-                final_response_results.append(
-                    WordAccentResult(
-                        furigana=yahoo_furigana, surface=yahoo_surface, accent=accents
-                    )
-                )
-
-                # Move OJAD index if skipped punctuation
-                if ojad_idx_cnt < len(ojad_results) and jaconv.kata2hira(
-                    ojad_results[ojad_idx_cnt]["text"].strip()
-                ) in ["、", "。", ",", "."]:
-                    ojad_idx_cnt += 1
-                continue
-
-            # Synchronize OJAD index
-            ojad_idx = ojad_idx_cnt
-
-            # Check OJAD boundary
-            if ojad_idx >= len(ojad_results):
-                logger.warning(f" -> OJAD Index Out of Bounds ({ojad_idx})")
-            else:
-                logger.debug(
-                    f"-> Comparing Yahoo '{yahoo_furigana_hira}'"
-                    f" vs OJAD '{ojad_results[ojad_idx]['text']}'"
-                )
-
-            # Move non-numeric OJAD index to the matching position
-            if not is_numeric:
-                while ojad_idx < len(
-                    ojad_results
-                ) and not yahoo_furigana_hira.startswith(
-                    jaconv.kata2hira(ojad_results[ojad_idx]["text"])
-                ):
-                    ojad_idx += 1
-
-            # catch the furigana from Yahoo with OJAD results
-            ojad_furigana = ""
-            temp_accents = []  # Use temp list to avoid partial data
-
-            # Define anchor(next Yahoo furigana) for numeric mode
-            next_yahoo_furigana = None
-            if i + 1 < len(furigana_results):
-                next_yahoo_furigana = jaconv.kata2hira(furigana_results[i + 1].furigana)
-
-            # Backup index
-            temp_ojad_idx = ojad_idx
-
-            # Number mode: grab OJAD until the anchor
-            if is_numeric:
-                while temp_ojad_idx < len(ojad_results):
-                    raw_text = ojad_results[temp_ojad_idx]["text"].strip()
-                    ojad_text = jaconv.kata2hira(raw_text)
-
-                    # Stop if reached the anchor
-                    if (
-                        next_yahoo_furigana 
-                        and next_yahoo_furigana.startswith(ojad_text)
-                    ):
-                        break
-                    
-                    # Stop if consumed too much data
-                    if len(ojad_furigana) > max(len(yahoo_surface) * 4, 12):
-                        logger.warning(
-                            f" -> Numeric consumption exceeded limit '{yahoo_surface}'."
-                        )
-                        break
-
-                    ojad_furigana += ojad_text
-                    temp_accents.append(
-                        AccentInfo(
-                            furigana=ojad_text,
-                            accent_marking_type=ojad_results[temp_ojad_idx]["accent"],
-                            length=len(ojad_text),
-                        )
-                    )
-                    temp_ojad_idx += 1
-            # Normal mode: grab OJAD until length match
-            else:
-                while len(ojad_furigana) < len(yahoo_furigana) and temp_ojad_idx < len(
-                    ojad_results
-                ):
-                    ojad_text = ojad_results[temp_ojad_idx]["text"]
-                    ojad_furigana += ojad_text
-                    temp_accents.append(
-                        AccentInfo(
-                            furigana=ojad_text,
-                            accent_marking_type=ojad_results[temp_ojad_idx]["accent"],
-                            length=len(ojad_text),
-                        )
-                    )
-                    temp_ojad_idx += 1
-
-            # Final matching check
-            is_match = False
-            if is_numeric:
-                # Numeric mode: only check if OJAD has furigana grabbed
-                is_match = len(ojad_furigana) > 0
-            else:
-                # Normal mode: check length and content
-                is_match = len(ojad_furigana) == len(
-                    yahoo_furigana
-                ) and jaconv.kata2hira(ojad_furigana) == jaconv.kata2hira(
-                    yahoo_furigana
-                )
-
-            if is_match:
-                logger.debug(f" -> MATCHED! OJAD: {ojad_furigana}")
-                accents.extend(temp_accents)
-
-                # Build final accent info list
-                accent_info_list = []
-                for idx, accent in enumerate(accents):
-                    accent_info_list.append(
-                        AccentInfo(
-                            furigana=accent.furigana,
-                            accent_marking_type=accent.accent_marking_type,
-                            length=accent.length,
-                        )
-                    )
-
-                ojad_idx_cnt = temp_ojad_idx  # Update global index
-
-                display_furigana = ojad_furigana if is_numeric else yahoo_furigana
-
-                # Build final response
-                if furigana_result.subword:
-                    yahoo_subword = furigana_result.subword
-                    logger.debug(
-                        "[Type Check] yahoo_subword element type: "
-                        f"{type(yahoo_subword[0])}"
-                    )
-                    logger.debug(f"[Data Check] yahoo_subword content: {yahoo_subword}")
-                    final_response_results.append(
-                        WordAccentResult(
-                            furigana=display_furigana,
-                            surface=yahoo_surface,
-                            accent=accent_info_list,
-                            subword=[
-                                WordResult(furigana=s.furigana, surface=s.surface)
-                                for s in yahoo_subword
-                            ],
-                        )
-                    )
-                else:
-                    final_response_results.append(
-                        WordAccentResult(
-                            furigana=display_furigana,
-                            surface=yahoo_surface,
-                            accent=accent_info_list,
-                        )
-                    )
-            else:
-                # [ERROR BLOCK]
-                logger.error(
-                    "-> MATCH FAILED."
-                    f"Yahoo: {yahoo_furigana} vs OJAD Assembly: {ojad_furigana}"
-                )
-
-                # Fallback to Yahoo furigana with no accent info
-                accent_info = AccentInfo(
-                    furigana=yahoo_furigana, 
-                    accent_marking_type=0, 
-                    length=len(yahoo_furigana)
-                )
-
-                final_response_results.append(
-                    WordAccentResult(
-                        furigana=yahoo_furigana,
-                        surface=yahoo_surface,
-                        accent=[accent_info],
-                    )
-                )
-
-                # Move OJAD index to next item to avoid infinite loop
-                if ojad_idx_cnt < len(ojad_results):
-                    ojad_idx_cnt += 1
-
-        return Response(status=200, result=final_response_results)
+        return Response(status=200, result=final_results)
 
     except Exception as e:
         logger.exception(f"Unexpected error occurred: {request.text}")

--- a/api/accent_marker.py
+++ b/api/accent_marker.py
@@ -3,6 +3,7 @@ An API that mark accent of given query text
 """
 
 import logging
+import re
 import string
 from typing import Any
 
@@ -274,6 +275,9 @@ async def mark_accent(
 
         logger.debug(f"🔍 [Data Check] First item:{furigana_results[0]}")
 
+        #accept negative integers and decimals
+        numeric_pattern = re.compile(r"^-?\d+(\.\d+)?$") 
+
         for i, furigana_result in enumerate(furigana_results):
             yahoo_furigana = furigana_result.furigana
             yahoo_surface = furigana_result.surface
@@ -286,7 +290,7 @@ async def mark_accent(
             )
 
             # Identify if the word is numeric
-            is_numeric = yahoo_surface.isdigit()
+            is_numeric = bool(numeric_pattern.match(yahoo_surface))
 
             # ignore non-kana/kanji and non-numeric words
             if (
@@ -307,6 +311,12 @@ async def mark_accent(
                         furigana=yahoo_furigana, surface=yahoo_surface, accent=accents
                     )
                 )
+
+                # Move OJAD index if skipped punctuation
+                if ojad_idx_cnt < len(ojad_results) and jaconv.kata2hira(
+                    ojad_results[ojad_idx_cnt]["text"].strip()
+                ) in ["、", "。", ",", "."]:
+                    ojad_idx_cnt += 1
                 continue
 
             # Synchronize OJAD index
@@ -345,11 +355,21 @@ async def mark_accent(
             # Number mode: grab OJAD until the anchor
             if is_numeric:
                 while temp_ojad_idx < len(ojad_results):
-                    ojad_text = jaconv.kata2hira(ojad_results[temp_ojad_idx]["text"])
+                    raw_text = ojad_results[temp_ojad_idx]["text"].strip()
+                    ojad_text = jaconv.kata2hira(raw_text)
 
-                    if next_yahoo_furigana and ojad_text.startswith(
-                        next_yahoo_furigana[:1]
+                    # Stop if reached the anchor
+                    if (
+                        next_yahoo_furigana 
+                        and next_yahoo_furigana.startswith(ojad_text)
                     ):
+                        break
+                    
+                    # Stop if consumed too much data
+                    if len(ojad_furigana) > max(len(yahoo_surface) * 4, 12):
+                        logger.warning(
+                            f" -> Numeric consumption exceeded limit '{yahoo_surface}'."
+                        )
                         break
 
                     ojad_furigana += ojad_text
@@ -442,6 +462,26 @@ async def mark_accent(
                     "-> MATCH FAILED."
                     f"Yahoo: {yahoo_furigana} vs OJAD Assembly: {ojad_furigana}"
                 )
+
+                # Fallback to Yahoo furigana with no accent info
+                accent_info = AccentInfo(
+                    furigana=yahoo_furigana, 
+                    accent_marking_type=0, 
+                    length=len(yahoo_furigana)
+                )
+
+                final_response_results.append(
+                    WordAccentResult(
+                        furigana=yahoo_furigana,
+                        surface=yahoo_surface,
+                        accent=[accent_info],
+                    )
+                )
+
+                # Move OJAD index to next item to avoid infinite loop
+                if ojad_idx_cnt < len(ojad_results):
+                    ojad_idx_cnt += 1
+
         return Response(status=200, result=final_response_results)
 
     except Exception as e:

--- a/api/accent_marker.py
+++ b/api/accent_marker.py
@@ -287,11 +287,13 @@ async def mark_accent(
 
             # Identify if the word is numeric
             is_numeric = yahoo_surface.isdigit()
-            
+
             # ignore non-kana/kanji and non-numeric words
-            if not furigana_result.subword and any(
-                not is_kana_or_kanji(chr) for chr in yahoo_furigana
-            ) and not is_numeric:
+            if (
+                not furigana_result.subword
+                and any(not is_kana_or_kanji(chr) for chr in yahoo_furigana)
+                and not is_numeric
+            ):
                 logger.debug(" -> Skipped (Not Kana/Kanji)")
                 accents.append(
                     AccentInfo(
@@ -312,7 +314,7 @@ async def mark_accent(
 
             # Check OJAD boundary
             if ojad_idx >= len(ojad_results):
-                logger.warning(f" -> OJAD Index Out of Bounds ({ojad_idx})")                
+                logger.warning(f" -> OJAD Index Out of Bounds ({ojad_idx})")
             else:
                 logger.debug(
                     f"-> Comparing Yahoo '{yahoo_furigana_hira}'"
@@ -321,7 +323,9 @@ async def mark_accent(
 
             # Move non-numeric OJAD index to the matching position
             if not is_numeric:
-                while ojad_idx < len(ojad_results) and not yahoo_furigana_hira.startswith(
+                while ojad_idx < len(
+                    ojad_results
+                ) and not yahoo_furigana_hira.startswith(
                     jaconv.kata2hira(ojad_results[ojad_idx]["text"])
                 ):
                     ojad_idx += 1
@@ -333,19 +337,21 @@ async def mark_accent(
             # Define anchor(next Yahoo furigana) for numeric mode
             next_yahoo_furigana = None
             if i + 1 < len(furigana_results):
-                next_yahoo_furigana = jaconv.kata2hira(furigana_results[i+1].furigana)
+                next_yahoo_furigana = jaconv.kata2hira(furigana_results[i + 1].furigana)
 
             # Backup index
             temp_ojad_idx = ojad_idx
-            
+
             # Number mode: grab OJAD until the anchor
             if is_numeric:
                 while temp_ojad_idx < len(ojad_results):
                     ojad_text = jaconv.kata2hira(ojad_results[temp_ojad_idx]["text"])
 
-                    if next_yahoo_furigana and ojad_text.startswith(next_yahoo_furigana[:1]):
+                    if next_yahoo_furigana and ojad_text.startswith(
+                        next_yahoo_furigana[:1]
+                    ):
                         break
-                        
+
                     ojad_furigana += ojad_text
                     temp_accents.append(
                         AccentInfo(
@@ -375,15 +381,18 @@ async def mark_accent(
             is_match = False
             if is_numeric:
                 # Numeric mode: only check if OJAD has furigana grabbed
-                is_match = len(ojad_furigana) > 0 
-            else:                
+                is_match = len(ojad_furigana) > 0
+            else:
                 # Normal mode: check length and content
-                is_match = (len(ojad_furigana) == len(yahoo_furigana) and 
-                            jaconv.kata2hira(ojad_furigana) == jaconv.kata2hira(yahoo_furigana))
+                is_match = len(ojad_furigana) == len(
+                    yahoo_furigana
+                ) and jaconv.kata2hira(ojad_furigana) == jaconv.kata2hira(
+                    yahoo_furigana
+                )
 
             if is_match:
                 logger.debug(f" -> MATCHED! OJAD: {ojad_furigana}")
-                accents.extend(temp_accents) 
+                accents.extend(temp_accents)
 
                 # Build final accent info list
                 accent_info_list = []


### PR DESCRIPTION
<!-- 請先閱讀我們手冊的 [How to PR](https://hackmd.io/@sessatakuma/pr_template#How-to-PR) 章節 -->
<!-- 記得修改PR標題成 conventional commit 之標題格式  -->

### 目的
解決 Yahoo API 無法提供數字假名讀音的問題，整合 OJAD 的音標資訊，使模型在輸出包含數字時，能正確顯示數字的假名與音調

### 方法／實作說明
由於 Yahoo API 對於數字僅回傳原始字串，而 OJAD 可回傳完整唸法，但此前對兩者的對齊邏輯導致無法使用OJAD的回傳，對此使用分流機制進行優化

透過 isdigit() 識別 token 是否為數字，並放寬 token 為數字的情況下的判定條件

- 主要修改：
  - api/accent_marker.py
  -  修改註解
- 關鍵實作：
  - 不對數字進行字串比對，而是用anchor來定位
  - 將對一般字與對數字的檢查分成兩種標準

### 附註
- TODO：
  - [ ] refactor `align_accent()`

