### PR TITLE
feat(docker): add docker compose setup for api-tools

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.github/
+.gitignore
+.python-version
+__pycache__/
+*.pyc
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.venv/
+README.md
+Procfile
+render.yaml
+vercel.json

--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,9 @@ __pycache__/
 .mypy_cache/
 .ruff_cache/
 .venv/
+.env
+.env.*
+!.env.example
 README.md
 Procfile
 render.yaml

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+YAHOO_API_KEY=your-yahoo-api-key
+API_TOOLS_KEY=change-me-to-a-secure-key
+API_TOOLS_PORT=8000
+API_TOOLS_ALLOW_ORIGINS=https://yourdomain.com
+API_TOOLS_ALLOWED_HOSTS=localhost,127.0.0.1

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,2 @@
 YAHOO_API_KEY=your-yahoo-api-key
-X_API_KEY=change-me-to-a-secure-key
 API_TOOLS_PORT=8000
-ALLOW_ORIGINS=https://yourdomain.com
-ALLOWED_HOSTS=localhost,127.0.0.1

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 YAHOO_API_KEY=your-yahoo-api-key
-API_TOOLS_KEY=change-me-to-a-secure-key
+X_API_KEY=change-me-to-a-secure-key
 API_TOOLS_PORT=8000
-API_TOOLS_ALLOW_ORIGINS=https://yourdomain.com
-API_TOOLS_ALLOWED_HOSTS=localhost,127.0.0.1
+ALLOW_ORIGINS=https://yourdomain.com
+ALLOWED_HOSTS=localhost,127.0.0.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM python:3.11-slim AS builder
 
 WORKDIR /app
 
-# Install uv for fast dependency management
-RUN pip install --no-cache-dir uv
+# Install uv for fast dependency management (pinned for reproducible builds)
+RUN pip install --no-cache-dir "uv==0.9.0"
 
 # Copy dependency files first for better layer caching
 COPY pyproject.toml uv.lock ./
@@ -13,13 +13,9 @@ RUN uv sync --frozen --no-dev --no-install-project
 
 COPY . .
 
-RUN python -m compileall -b /app \
-    && python - <<'PY'
-from pathlib import Path
-
-for path in Path("/app").rglob("*.py"):
-    path.unlink()
-PY
+# Compile only our app code (skip .venv) and drop the .py sources
+RUN python -m compileall -b -q main.py api config \
+    && find main.py api config -name "*.py" -delete
 
 FROM python:3.11-slim
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+FROM python:3.11-slim AS builder
+
+WORKDIR /app
+
+# Install uv for fast dependency management
+RUN pip install --no-cache-dir uv
+
+# Copy dependency files first for better layer caching
+COPY pyproject.toml uv.lock ./
+
+# Install dependencies using uv
+RUN uv sync --frozen --no-dev --no-install-project
+
+COPY . .
+
+RUN python -m compileall -b /app \
+    && python - <<'PY'
+from pathlib import Path
+
+for path in Path("/app").rglob("*.py"):
+    path.unlink()
+PY
+
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Copy installed dependencies and app from builder
+COPY --from=builder /app/.venv /app/.venv
+COPY --from=builder /app/main.pyc /app/main.pyc
+COPY --from=builder /app/api /app/api
+COPY --from=builder /app/config /app/config
+
+# Set PATH to use venv binaries
+ENV PATH="/app/.venv/bin:$PATH"
+ENV PYTHONUNBUFFERED=1
+
+EXPOSE 8000
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -212,11 +212,11 @@ After build the environment, you should also obtain a Yahoo API Client ID from [
 For local standalone development, copy `.env.example` to `.env` in this directory and fill in the values:
 
 ```env
-YAHOO_API_KEY=<Our Yahoo API Key>
-X_API_KEY=<Our X-API-KEY>
-ALLOW_ORIGINS=<Our Allowed Origins>
-ALLOWED_HOSTS=<Our Allowed Hosts>
+YAHOO_API_KEY=<Our Yahoo API Key>   # required — app asserts on startup
+API_TOOLS_PORT=8000                 # optional — host-side port for docker compose (default 8000)
 ```
+
+Authentication (`X-API-KEY`), CORS, and trusted-host middleware were intentionally removed; this service is expected to run behind the parent backend or on a private network.
 
 In [jpcorrect-backend](https://github.com/sessatakuma/jpcorrect-backend), the equivalent workflow is `make api-tools`.
 

--- a/README.md
+++ b/README.md
@@ -209,23 +209,29 @@ uv sync
 
 After build the environment, you should also obtain a Yahoo API Client ID from [Yahoo Japan website](https://developer.yahoo.co.jp/sitemap/).
 
-For standalone Docker deployment, copy `.env.example` to `.env` in this directory and fill in the values:
+For local standalone development, copy `.env.example` to `.env` in this directory and fill in the values:
 
 ```env
 YAHOO_API_KEY=<Our Yahoo API Key>
-API_TOOLS_KEY=<Our X-API-KEY>
-API_TOOLS_PORT=8000
-API_TOOLS_ALLOW_ORIGINS=<Our Allowed Origins>
-API_TOOLS_ALLOWED_HOSTS=<Our Allowed Hosts>
+X_API_KEY=<Our X-API-KEY>
+ALLOW_ORIGINS=<Our Allowed Origins>
+ALLOWED_HOSTS=<Our Allowed Hosts>
 ```
 
 Then run:
 
 ```bash
-docker compose --env-file .env up -d --build
+uv run uvicorn main:app --host 127.0.0.1 --port 8000
 ```
 
-For local non-Docker development, keep using `uv sync` and provide the runtime variables expected by the app (`YAHOO_API_KEY`, `ALLOW_ORIGINS`, `ALLOWED_HOSTS`, `X_API_KEY`) through your local environment or a compatible `.env` workflow.
+In [jpcorrect-backend](https://github.com/sessatakuma/jpcorrect-backend), the equivalent workflow is `make api-tools`.
+
+If you prefer to run `API-tools` through Docker from this subdirectory, you can also use:
+
+```bash
+cp .env.example .env
+docker compose up -d --build
+```
 
 ## How to run?
 

--- a/README.md
+++ b/README.md
@@ -209,14 +209,23 @@ uv sync
 
 After build the environment, you should also obtain a Yahoo API Client ID from [Yahoo Japan website](https://developer.yahoo.co.jp/sitemap/).
 
-Then add the sensitive information in file `.env` as follows:
+For standalone Docker deployment, copy `.env.example` to `.env` in this directory and fill in the values:
 
 ```env
 YAHOO_API_KEY=<Our Yahoo API Key>
-ALLOW_ORIGINS=<Our Allowed Origins>
-ALLOWED_HOSTS=<Our Allowed Hosts>
-X_API_KEY=<Our X-API-KEY>
+API_TOOLS_KEY=<Our X-API-KEY>
+API_TOOLS_PORT=8000
+API_TOOLS_ALLOW_ORIGINS=<Our Allowed Origins>
+API_TOOLS_ALLOWED_HOSTS=<Our Allowed Hosts>
 ```
+
+Then run:
+
+```bash
+docker compose --env-file .env up -d --build
+```
+
+For local non-Docker development, keep using `uv sync` and provide the runtime variables expected by the app (`YAHOO_API_KEY`, `ALLOW_ORIGINS`, `ALLOWED_HOSTS`, `X_API_KEY`) through your local environment or a compatible `.env` workflow.
 
 ## How to run?
 

--- a/README.md
+++ b/README.md
@@ -218,25 +218,20 @@ ALLOW_ORIGINS=<Our Allowed Origins>
 ALLOWED_HOSTS=<Our Allowed Hosts>
 ```
 
-Then run:
-
-```bash
-uv run uvicorn main:app --host 127.0.0.1 --port 8000
-```
-
 In [jpcorrect-backend](https://github.com/sessatakuma/jpcorrect-backend), the equivalent workflow is `make api-tools`.
-
-If you prefer to run `API-tools` through Docker from this subdirectory, you can also use:
-
-```bash
-cp .env.example .env
-docker compose up -d --build
-```
 
 ## How to run?
 
+Run the service with `uv` (dev mode, with auto-reload):
+
 ```bash
-uvicorn main:app --reload
+uv run uvicorn main:app --host 127.0.0.1 --port 8000 --reload
+```
+
+Or run it through Docker from this subdirectory:
+
+```bash
+docker compose up -d --build
 ```
 
 To check the functionality, you may send POST request with curl as follows.

--- a/config/settings.py
+++ b/config/settings.py
@@ -6,16 +6,3 @@ load_dotenv()
 
 YAHOO_API_KEY: str = os.getenv("YAHOO_API_KEY", "")
 assert YAHOO_API_KEY, "YAHOO_API_KEY environment variable is not set"
-
-ALLOWED_HOSTS: list[str] = os.getenv("ALLOWED_HOSTS", "").split(",")
-assert ALLOWED_HOSTS and all(ALLOWED_HOSTS), (
-    "ALLOWED_HOSTS environment variable is not set"
-)
-
-ALLOW_ORIGINS: list[str] = os.getenv("ALLOW_ORIGINS", "").split(",")
-assert ALLOW_ORIGINS and all(ALLOW_ORIGINS), (
-    "ALLOW_ORIGINS environment variable is not set"
-)
-
-X_API_KEY: str = os.getenv("X_API_KEY", "")
-assert X_API_KEY, "X_API_KEY environment variable is not set"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,4 +9,10 @@ services:
             - .env
         ports:
             - "127.0.0.1:${API_TOOLS_PORT:-8000}:8000"
+        networks:
+            - jpcorrect-shared
         restart: unless-stopped
+
+networks:
+    jpcorrect-shared:
+        external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,8 @@ services:
             context: .
             dockerfile: Dockerfile
         container_name: jpcorrect-api-tools
-        environment:
-            YAHOO_API_KEY: ${YAHOO_API_KEY}
-            X_API_KEY: ${API_TOOLS_KEY}
-            ALLOW_ORIGINS: ${API_TOOLS_ALLOW_ORIGINS:-*}
-            ALLOWED_HOSTS: ${API_TOOLS_ALLOWED_HOSTS:-*}
+        env_file:
+            - .env
         ports:
             - "127.0.0.1:${API_TOOLS_PORT:-8000}:8000"
         restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+---
+services:
+    api-tools:
+        build:
+            context: .
+            dockerfile: Dockerfile
+        container_name: jpcorrect-api-tools
+        environment:
+            YAHOO_API_KEY: ${YAHOO_API_KEY}
+            X_API_KEY: ${API_TOOLS_KEY}
+            ALLOW_ORIGINS: ${API_TOOLS_ALLOW_ORIGINS:-*}
+            ALLOWED_HOSTS: ${API_TOOLS_ALLOWED_HOSTS:-*}
+        ports:
+            - "127.0.0.1:${API_TOOLS_PORT:-8000}:8000"
+        restart: unless-stopped

--- a/main.py
+++ b/main.py
@@ -8,23 +8,13 @@ An API interface that provide two functionalities
 """
 
 import logging
-import secrets
 from contextlib import asynccontextmanager
 from typing import AsyncGenerator
 
 import httpx
-from fastapi import Depends, FastAPI, HTTPException, Security
-from fastapi.middleware.cors import CORSMiddleware
-from fastapi.middleware.trustedhost import TrustedHostMiddleware
-from fastapi.security.api_key import APIKeyHeader
-from slowapi import Limiter, _rate_limit_exceeded_handler
-from slowapi.errors import RateLimitExceeded
-from slowapi.middleware import SlowAPIMiddleware
-from slowapi.util import get_remote_address
-from starlette.status import HTTP_403_FORBIDDEN
+from fastapi import FastAPI
 
 from api import accent_marker, dict_query, furigana_marker, sentence_query, usage_query
-from config.settings import ALLOW_ORIGINS, ALLOWED_HOSTS, X_API_KEY
 
 
 @asynccontextmanager
@@ -48,57 +38,13 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
 app = FastAPI(lifespan=lifespan)
 
-# Configure CORS middleware
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=ALLOW_ORIGINS,
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
-
-# Configure Trusted Host middleware
-app.add_middleware(
-    TrustedHostMiddleware,
-    allowed_hosts=ALLOWED_HOSTS,
-)
-
-# TODO: adjust rate limit as needed for each api endpoint
-limiter = Limiter(
-    key_func=get_remote_address,
-    default_limits=["60/minute"],
-)
-app.state.limiter = limiter
-app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)  # type: ignore
-app.add_middleware(SlowAPIMiddleware)
-
-# API Key Header for API key authentication
-api_key_header = APIKeyHeader(name="X-API-KEY", auto_error=False)
-
-
-async def get_api_key(api_key: str = Security(api_key_header)) -> None:
-    if not secrets.compare_digest(api_key or "", X_API_KEY):
-        raise HTTPException(
-            status_code=HTTP_403_FORBIDDEN, detail="Could not validate credentials"
-        )
-
-
 # Include routers from different modules
-app.include_router(
-    accent_marker.router, prefix="/api", dependencies=[Depends(get_api_key)]
-)
-app.include_router(
-    furigana_marker.router, prefix="/api", dependencies=[Depends(get_api_key)]
-)
-app.include_router(
-    usage_query.router, prefix="/api", dependencies=[Depends(get_api_key)]
-)
-app.include_router(
-    dict_query.router, prefix="/api", dependencies=[Depends(get_api_key)]
-)
-app.include_router(
-    sentence_query.router, prefix="/api", dependencies=[Depends(get_api_key)]
-)
+app.include_router(accent_marker.router, prefix="/api")
+app.include_router(furigana_marker.router, prefix="/api")
+app.include_router(usage_query.router, prefix="/api")
+app.include_router(dict_query.router, prefix="/api")
+app.include_router(sentence_query.router, prefix="/api")
+
 logging.basicConfig(
     level=logging.INFO,
     format="{asctime} [{levelname:^8s}] {message} ({name}.{module}:{lineno})",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ dependencies = [
     "jaconv>=0.4.0",
     "neologdn>=0.5.4",
     "pydantic>=2.12.3",
-    "slowapi>=0.1.9",
     "uvicorn>=0.38.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -45,7 +45,6 @@ dependencies = [
     { name = "jaconv" },
     { name = "neologdn" },
     { name = "pydantic" },
-    { name = "slowapi" },
     { name = "uvicorn" },
 ]
 
@@ -64,7 +63,6 @@ requires-dist = [
     { name = "jaconv", specifier = ">=0.4.0" },
     { name = "neologdn", specifier = ">=0.5.4" },
     { name = "pydantic", specifier = ">=2.12.3" },
-    { name = "slowapi", specifier = ">=0.1.9" },
     { name = "uvicorn", specifier = ">=0.38.0" },
 ]
 
@@ -115,18 +113,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
-]
-
-[[package]]
-name = "deprecated"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "wrapt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
 ]
 
 [[package]]
@@ -230,20 +216,6 @@ wheels = [
 ]
 
 [[package]]
-name = "limits"
-version = "5.6.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "deprecated" },
-    { name = "packaging" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/e5/c968d43a65128cd54fb685f257aafb90cd5e4e1c67d084a58f0e4cbed557/limits-5.6.0.tar.gz", hash = "sha256:807fac75755e73912e894fdd61e2838de574c5721876a19f7ab454ae1fffb4b5", size = 182984, upload-time = "2025-09-29T17:15:22.689Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/96/4fcd44aed47b8fcc457653b12915fcad192cd646510ef3f29fd216f4b0ab/limits-5.6.0-py3-none-any.whl", hash = "sha256:b585c2104274528536a5b68864ec3835602b3c4a802cd6aa0b07419798394021", size = 60604, upload-time = "2025-09-29T17:15:18.419Z" },
-]
-
-[[package]]
 name = "mypy"
 version = "1.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -293,15 +265,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/41/1761e61ac4fbb31c69ae7ca1436f1ebd4b080c7c01b025ccd634710696c6/neologdn-0.5.6-cp311-cp311-win32.whl", hash = "sha256:50d3c7acd0eae7dcdf093b2ff04ccb863221ca71759527251b7bca350ed8bbc7", size = 44886, upload-time = "2025-12-02T05:48:29.972Z" },
     { url = "https://files.pythonhosted.org/packages/c6/1c/bf2ca89584b5769cbbfcc8da7d98b9770d4a94ce08c4e608adc18457eb9f/neologdn-0.5.6-cp311-cp311-win_amd64.whl", hash = "sha256:9b87e8c9b2d64c5d53dded9a9e03dbab808fea068b4974bdb8917300bad382d2", size = 47676, upload-time = "2025-12-02T05:48:30.955Z" },
     { url = "https://files.pythonhosted.org/packages/b7/4c/e90f45e666474bf1a64d9f958463745d4ff34dfa9b331fd06e95d1873558/neologdn-0.5.6-cp311-cp311-win_arm64.whl", hash = "sha256:bf167d599c11e24d3f5a1ce7fa7888c4d9d79eba5ca138a0ebf51eaf0c790c5f", size = 42548, upload-time = "2025-12-02T05:48:31.942Z" },
-]
-
-[[package]]
-name = "packaging"
-version = "25.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
 ]
 
 [[package]]
@@ -401,18 +364,6 @@ wheels = [
 ]
 
 [[package]]
-name = "slowapi"
-version = "0.1.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "limits" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a0/99/adfc7f94ca024736f061257d39118e1542bade7a52e86415a4c4ae92d8ff/slowapi-0.1.9.tar.gz", hash = "sha256:639192d0f1ca01b1c6d95bf6c71d794c3a9ee189855337b4821f7f457dddad77", size = 14028, upload-time = "2024-02-05T12:11:52.13Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/bb/f71c4b7d7e7eb3fc1e8c0458a8979b912f40b58002b9fbf37729b8cb464b/slowapi-0.1.9-py3-none-any.whl", hash = "sha256:cfad116cfb84ad9d763ee155c1e5c5cbf00b0d47399a769b227865f5df576e36", size = 14670, upload-time = "2024-02-05T12:11:50.898Z" },
-]
-
-[[package]]
 name = "soupsieve"
 version = "2.8.1"
 source = { registry = "https://pypi.org/simple" }
@@ -466,25 +417,4 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c3/d1/8f3c683c9561a4e6689dd3b1d345c815f10f86acd044ee1fb9a4dcd0b8c5/uvicorn-0.40.0.tar.gz", hash = "sha256:839676675e87e73694518b5574fd0f24c9d97b46bea16df7b8c05ea1a51071ea", size = 81761, upload-time = "2025-12-21T14:16:22.45Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3d/d8/2083a1daa7439a66f3a48589a57d576aa117726762618f6bb09fe3798796/uvicorn-0.40.0-py3-none-any.whl", hash = "sha256:c6c8f55bc8bf13eb6fa9ff87ad62308bbbc33d0b67f84293151efe87e0d5f2ee", size = 68502, upload-time = "2025-12-21T14:16:21.041Z" },
-]
-
-[[package]]
-name = "wrapt"
-version = "2.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/49/2a/6de8a50cb435b7f42c46126cf1a54b2aab81784e74c8595c8e025e8f36d3/wrapt-2.0.1.tar.gz", hash = "sha256:9c9c635e78497cacb81e84f8b11b23e0aacac7a136e73b8e5b2109a1d9fc468f", size = 82040, upload-time = "2025-11-07T00:45:33.312Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/60/553997acf3939079dab022e37b67b1904b5b0cc235503226898ba573b10c/wrapt-2.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0e17283f533a0d24d6e5429a7d11f250a58d28b4ae5186f8f47853e3e70d2590", size = 77480, upload-time = "2025-11-07T00:43:30.573Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/50/e5b3d30895d77c52105c6d5cbf94d5b38e2a3dd4a53d22d246670da98f7c/wrapt-2.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:85df8d92158cb8f3965aecc27cf821461bb5f40b450b03facc5d9f0d4d6ddec6", size = 60690, upload-time = "2025-11-07T00:43:31.594Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/40/660b2898703e5cbbb43db10cdefcc294274458c3ca4c68637c2b99371507/wrapt-2.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c1be685ac7700c966b8610ccc63c3187a72e33cab53526a27b2a285a662cd4f7", size = 61578, upload-time = "2025-11-07T00:43:32.918Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/36/825b44c8a10556957bc0c1d84c7b29a40e05fcf1873b6c40aa9dbe0bd972/wrapt-2.0.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:df0b6d3b95932809c5b3fecc18fda0f1e07452d05e2662a0b35548985f256e28", size = 114115, upload-time = "2025-11-07T00:43:35.605Z" },
-    { url = "https://files.pythonhosted.org/packages/83/73/0a5d14bb1599677304d3c613a55457d34c344e9b60eda8a737c2ead7619e/wrapt-2.0.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4da7384b0e5d4cae05c97cd6f94faaf78cc8b0f791fc63af43436d98c4ab37bb", size = 116157, upload-time = "2025-11-07T00:43:37.058Z" },
-    { url = "https://files.pythonhosted.org/packages/01/22/1c158fe763dbf0a119f985d945711d288994fe5514c0646ebe0eb18b016d/wrapt-2.0.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ec65a78fbd9d6f083a15d7613b2800d5663dbb6bb96003899c834beaa68b242c", size = 112535, upload-time = "2025-11-07T00:43:34.138Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/28/4f16861af67d6de4eae9927799b559c20ebdd4fe432e89ea7fe6fcd9d709/wrapt-2.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7de3cc939be0e1174969f943f3b44e0d79b6f9a82198133a5b7fc6cc92882f16", size = 115404, upload-time = "2025-11-07T00:43:39.214Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/8b/7960122e625fad908f189b59c4aae2d50916eb4098b0fb2819c5a177414f/wrapt-2.0.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:fb1a5b72cbd751813adc02ef01ada0b0d05d3dcbc32976ce189a1279d80ad4a2", size = 111802, upload-time = "2025-11-07T00:43:40.476Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/73/7881eee5ac31132a713ab19a22c9e5f1f7365c8b1df50abba5d45b781312/wrapt-2.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3fa272ca34332581e00bf7773e993d4f632594eb2d1b0b162a9038df0fd971dd", size = 113837, upload-time = "2025-11-07T00:43:42.921Z" },
-    { url = "https://files.pythonhosted.org/packages/45/00/9499a3d14e636d1f7089339f96c4409bbc7544d0889f12264efa25502ae8/wrapt-2.0.1-cp311-cp311-win32.whl", hash = "sha256:fc007fdf480c77301ab1afdbb6ab22a5deee8885f3b1ed7afcb7e5e84a0e27be", size = 58028, upload-time = "2025-11-07T00:43:47.369Z" },
-    { url = "https://files.pythonhosted.org/packages/70/5d/8f3d7eea52f22638748f74b102e38fdf88cb57d08ddeb7827c476a20b01b/wrapt-2.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:47434236c396d04875180171ee1f3815ca1eada05e24a1ee99546320d54d1d1b", size = 60385, upload-time = "2025-11-07T00:43:44.34Z" },
-    { url = "https://files.pythonhosted.org/packages/14/e2/32195e57a8209003587bbbad44d5922f13e0ced2a493bb46ca882c5b123d/wrapt-2.0.1-cp311-cp311-win_arm64.whl", hash = "sha256:837e31620e06b16030b1d126ed78e9383815cbac914693f54926d816d35d8edf", size = 58893, upload-time = "2025-11-07T00:43:46.161Z" },
-    { url = "https://files.pythonhosted.org/packages/15/d1/b51471c11592ff9c012bd3e2f7334a6ff2f42a7aed2caffcf0bdddc9cb89/wrapt-2.0.1-py3-none-any.whl", hash = "sha256:4d2ce1bf1a48c5277d7969259232b57645aae5686dba1eaeade39442277afbca", size = 44046, upload-time = "2025-11-07T00:45:32.116Z" },
 ]


### PR DESCRIPTION
<!-- 請先閱讀我們手冊的 [How to PR](https://hackmd.io/@sessatakuma/pr_template#How-to-PR) 章節 -->
<!-- 記得修改PR標題成 conventional commit 之標題格式  -->

### 目的
Provide a Docker-based workflow for running the `API-tools` Python service standalone, alongside the existing `uv run` flow, so contributors can spin it up with a single `docker compose up`.

### 方法／實作說明
新增 Docker 相關設定檔，並在 README 補上對應的執行說明與 `.env.example` 範本。額外從 `feat/disable-auth`（remote 分支已於 cherry-pick 後刪除）cherry-pick 兩個 commit — `f3e708d` → `36748e6`（移除 auth middleware）與 `ac5e346` → `7b8a0a6`（移除 `slowapi`）— 把 `API-tools` 內既有的 `X-API-KEY` 驗證、CORS／TrustedHost／rate-limit middleware 全數移除，與上游 backend 端「停用驗證」的方向對齊；連帶把 `.env.example` 與 README 的 env 區塊收斂到實際還會被讀的兩個變數。

- Docker 設定：
  - `Dockerfile`: multi-stage build using `python:3.11-slim` + `uv sync --frozen --no-dev`, compiles `.py` → `.pyc` and drops sources in the runtime image
  - `docker-compose.yml`: single `api-tools` service, binds `127.0.0.1:${API_TOOLS_PORT:-8000}:8000`, loads `.env`
  - `.dockerignore`: excludes git/venv/cache/deploy-only files from the build context
  - `README.md`: documents both the local `uv run uvicorn` workflow and the new `docker compose up -d --build` workflow
- 關鍵實作：
  - Builder stage uses `uv sync --no-install-project` so the venv layer is cached independently of source changes
  - Runtime image only copies `.venv`, compiled `main.pyc`, and the `api`/`config` packages — keeps the image lean
  - Port is bound to `127.0.0.1` only, matching the existing local-dev convention

- Auth／middleware 移除（cherry-picked from `feat/disable-auth`，原 remote 分支已刪除；本分支 commit `36748e6` + `7b8a0a6`）：
  - `main.py`: 移除 `APIKeyHeader`（`X-API-KEY`）驗證、`CORSMiddleware`、`TrustedHostMiddleware`、`SlowAPIMiddleware`／`Limiter` 等所有 middleware 設定；五個 router (`accent_marker`、`furigana_marker`、`usage_query`、`dict_query`、`sentence_query`) 不再帶 `Depends(get_api_key)`
  - `config/settings.py`: 移除 `X_API_KEY`、`ALLOW_ORIGINS`、`ALLOWED_HOSTS` 三個 env 讀取與 `assert`，僅保留 `YAHOO_API_KEY`
  - `pyproject.toml` / `uv.lock`: 移除 `slowapi`（連帶 `limits`、`deprecated`、`wrapt`、`packaging` 等遞迴相依套件）
  - 影響：API-tools 現在直接以未驗證、未限流的方式對外提供服務；存取控制移交給上層 backend (`CLIENT_API_KEY` middleware) 以及 compose 預設 `127.0.0.1` bind 把外網阻擋掉

- Docs／env 收斂：
  - `.env.example`: 只保留 `YAHOO_API_KEY`（app 啟動會 `assert`）與 `API_TOOLS_PORT`（compose host-side bind，預設 8000）；移除已不再被讀的 `X_API_KEY`／`ALLOW_ORIGINS`／`ALLOWED_HOSTS`
  - `README.md`: 同步 env 範例區塊，並補一行說明這個服務已不再做驗證／CORS／trusted-host，預期跑在 parent backend 後面或私網內

### Review feedback addressed (all fixed in `1ea5b1f`)

Copilot left 4 inline findings; Codex reviewed and reported no major issues. Resolutions:

| # | File | Finding | Fix in `1ea5b1f` |
|---|---|---|---|
| 1 | `.dockerignore` | `.env` / `.env.*` not excluded — secrets could leak into build context / layer cache | Added `.env` and `.env.*` to `.dockerignore`, with `!.env.example` exception so the template still ships |
| 2 | `Dockerfile` | `compileall` + `rglob` deletion targeted `/app`, so it also traversed `.venv` — bloats build time and complicates debugging | Replaced `/app`-wide pass with `python -m compileall -b -q main.py api config && find main.py api config -name "*.py" -delete`, leaving `.venv` untouched |
| 3 | `Dockerfile` | `pip install --no-cache-dir uv` was unpinned — undermined the reproducible `uv sync --frozen` build | Pinned to `uv==0.9.0` (matches the version in our `uv.lock` workflow) for deterministic Docker builds |
| 4 | `README.md` | "Build Environment" section showed `uv run uvicorn ... --host/--port` but "How to run?" below still showed `uvicorn main:app --reload` — two inconsistent entry points | Removed the duplicate block from Build Environment; "How to run?" is now the single source of truth (`uv run uvicorn main:app --host 127.0.0.1 --port 8000 --reload` + Docker alternative) |

### 關聯 Issue
Refs sessatakuma/jpcorrect-backend#37 — parent-repo issue covering self-host on tuf + CD build. This PR provides the standalone Docker setup that the parent repo's deploy stack relies on. Closing happens from the parent repo's PR (sessatakuma/jpcorrect-backend#38), since GitHub does not auto-close cross-repo references.

### 附註
- The compose stack is intentionally scoped to `API-tools` only; the Go backend stack lives in the parent repo's `compose.deploy.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
