### PR TITLE
feat(accent): reading override layer + streaming MarkAccent endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,6 @@ __marimo__/
 
 # Secrest files
 secret*
+
+data/
+output/

--- a/api/accent/align.py
+++ b/api/accent/align.py
@@ -1,11 +1,12 @@
 """Align Yahoo Furigana tokens with OJAD per-mora accent entries.
 
-`align_accent()` walks the Yahoo token list and consumes OJAD entries
-in order, emitting one `WordAccentResult` per Yahoo token. Numeric
-tokens have no Yahoo furigana to compare against so they use a
-length-anchor heuristic (stop when OJAD reaches the next Yahoo
-token's reading); kana / kanji tokens use literal length + content
-matching under kata2hira folding.
+`align_accent()` builds a Needleman-Wunsch-style DP over
+(yahoo_token, ojad_entry) pairs: for every Yahoo token we consider letting
+it consume k contiguous OJAD entries (k ∈ [0, K_MAX]), with the per-token
+cost depending on token shape (punct / numeric / kana) and edit distance
+over rendaku-folded strings for kana tokens. This replaces the older
+greedy aligner whose +1 fallback path cascaded a single mismatch into
+type-0 fallback for every downstream token.
 
 Alignment itself uses `numeric_pattern` and `is_kana_or_kanji`. The
 adjacent `punctuation_marks`, `skip_marks`, and `clean_query` are
@@ -128,207 +129,279 @@ def is_kana_or_kanji(char: Any) -> bool:
     return False
 
 
+# Yahoo returns "dictionary form" furigana (no rendaku), while OJAD returns the
+# actually pronounced kana (with rendaku/sequential-voicing applied). When
+# Yahoo says "ふんかん" and OJAD says "ぷんかん", literal startswith / equality
+# checks would never match and the alignment would cascade-fail. We compare
+# under a normalisation that folds each voiced/half-voiced kana to its
+# voiceless base, so ぷ↔ふ, ば↔は, ご↔こ etc. all alias together.
+_VOICING_FOLD: dict[str, str] = {
+    "が": "か", "ぎ": "き", "ぐ": "く", "げ": "け", "ご": "こ",
+    "ざ": "さ", "じ": "し", "ず": "す", "ぜ": "せ", "ぞ": "そ",
+    "だ": "た", "ぢ": "ち", "づ": "つ", "で": "て", "ど": "と",
+    "ば": "は", "び": "ひ", "ぶ": "ふ", "べ": "へ", "ぼ": "ほ",
+    "ぱ": "は", "ぴ": "ひ", "ぷ": "ふ", "ぺ": "へ", "ぽ": "ほ",
+}  # fmt: skip
+
+
+def _norm(s: str) -> str:
+    """Kata→hira plus voicing fold for rendaku-tolerant alignment."""
+    hira = jaconv.kata2hira(s)
+    return "".join(_VOICING_FOLD.get(c, c) for c in hira)
+
+
+# --- DP aligner ----------------------------------------------------------------
+#
+# The greedy aligner this replaced had two fatal failure modes: a numeric
+# anchor that over-consumed when Yahoo and OJAD disagreed on a phrase
+# boundary, and a fallback path that advanced OJAD by exactly +1 — so a
+# single mismatch cascaded into type-0 fallback for every downstream token.
+#
+# Instead we now build a Needleman-Wunsch-style DP over (yahoo_token,
+# ojad_entry) pairs. Each cell dp[i][j] holds the minimum total cost to
+# explain Yahoo tokens [0..i) using OJAD entries [0..j). For every (i, j)
+# we try consuming k OJAD entries for token i with k ∈ [0, K_MAX]; the
+# per-token cost depends on token shape (punctuation / numeric / kana) and
+# uses edit distance over rendaku-folded strings for kana tokens. A bad
+# token costs O(1); downstream tokens stay aligned.
+
+_K_MAX = 16  # max OJAD entries one Yahoo token can consume
+_INF = float("inf")
+_FALLBACK_COST = 3.0  # cost of giving up on a single token (k=0 for kana/numeric)
+_OJAD_PUNCT_TEXTS = {"、", "。", ",", ".", "?", "!", "！", "？"}
+
+
+# Substitutions are cheaper than insertions/deletions: a substitution keeps
+# the yahoo↔ojad mora-count alignment intact (the kind of mismatch we
+# *expect* — rendaku, reading variants like 等→とう/など), while ins/del
+# means the two sources disagree on mora count, which is much less common
+# and almost always a worse alignment. With sub<0.5, the DP correctly
+# prefers a same-length span with two substitutions (cost 0.8) over a
+# shorter span with one deletion (cost 1.0). This breaks the tie that was
+# letting OJAD's `う` from `等→とう` leak forward onto the next token.
+_SUB_COST = 0.4
+
+
+def _edit_distance(a: str, b: str) -> float:
+    """Weighted Levenshtein with sub_cost=0.4, ins/del=1.0.
+    Used over rendaku-folded strings only."""
+    if a == b:
+        return 0.0
+    if not a:
+        return float(len(b))
+    if not b:
+        return float(len(a))
+    prev: list[float] = [float(j) for j in range(len(b) + 1)]
+    for i, ca in enumerate(a, 1):
+        curr: list[float] = [float(i)] + [0.0] * len(b)
+        for j, cb in enumerate(b, 1):
+            if ca == cb:
+                curr[j] = prev[j - 1]
+            else:
+                curr[j] = min(
+                    prev[j - 1] + _SUB_COST,  # substitute
+                    prev[j] + 1.0,  # delete from a
+                    curr[j - 1] + 1.0,  # insert into a
+                )
+        prev = curr
+    return prev[-1]
+
+
+def _is_punct_token(furigana: str, is_numeric: bool) -> bool:
+    if is_numeric or not furigana:
+        return False
+    return all(not is_kana_or_kanji(c) for c in furigana)
+
+
+def _match_cost(
+    token: Any, span_texts: list[str], is_numeric: bool, is_punct: bool
+) -> float:
+    """Cost of letting `token` consume the given OJAD-text span."""
+    k = len(span_texts)
+    concat = "".join(span_texts)
+
+    if is_punct:
+        if k == 0:
+            return 0.0
+        if k == 1:
+            stripped = span_texts[0].strip()
+            yahoo_stripped = token.furigana.strip()
+            # Free-consume only if the OJAD entry actually matches this
+            # token's punct (or is empty). Without this, two adjacent
+            # punct tokens (e.g. "。" then "\n") could both consume the
+            # single OJAD "。" at zero cost and DP would arbitrarily give
+            # it to the wrong one.
+            if not stripped:
+                return 0.0
+            if stripped == yahoo_stripped:
+                return 0.0
+        return _INF
+
+    if is_numeric:
+        if k == 0:
+            return _FALLBACK_COST
+        # Numerics have no Yahoo furigana to compare against. Accept any
+        # reasonable count of morae; only penalise blatantly over-long spans.
+        upper = max(4, len(token.surface) * 4)
+        return 0.0 if k <= upper else float(k - upper)
+
+    # Kana / kanji token: compare under rendaku fold.
+    if k == 0:
+        return _FALLBACK_COST
+    y_norm = _norm(token.furigana)
+    o_norm = _norm(concat)
+    # Cheap length pre-filter — keeps the DP fast and prevents pathological
+    # "consume 12 OJAD entries to match a 2-mora Yahoo token" alignments.
+    if abs(len(y_norm) - len(o_norm)) > 3:
+        return _INF
+    return _edit_distance(y_norm, o_norm)
+
+
+def _build_word_result(token: Any, ojad_span: list[dict[str, Any]]) -> WordAccentResult:
+    """Wrap an aligned (token, OJAD-span) pair into a WordAccentResult."""
+    yahoo_surface = token.surface
+    yahoo_furigana = token.furigana
+    is_numeric = bool(numeric_pattern.match(yahoo_surface))
+    subword = (
+        [WordResult(furigana=s.furigana, surface=s.surface) for s in token.subword]
+        if token.subword
+        else []
+    )
+
+    if not ojad_span:
+        # k=0 path: emit type-0 fallback so the downstream override pass and
+        # callers still see one AccentInfo per token.
+        return WordAccentResult(
+            surface=yahoo_surface,
+            furigana=yahoo_furigana,
+            accent=[
+                AccentInfo(
+                    furigana=yahoo_furigana,
+                    accent_marking_type=0,
+                    length=len(yahoo_furigana),
+                )
+            ],
+            subword=subword,
+        )
+
+    # Drop OJAD entries with empty text (phrase-boundary sentinels). They
+    # carry no audible mora and would surface as a stray "(…||0)" row.
+    voiced_span = [e for e in ojad_span if e["text"]]
+    if not voiced_span:
+        return WordAccentResult(
+            surface=yahoo_surface,
+            furigana=yahoo_furigana,
+            accent=[
+                AccentInfo(
+                    furigana=yahoo_furigana,
+                    accent_marking_type=0,
+                    length=len(yahoo_furigana),
+                )
+            ],
+            subword=subword,
+        )
+    accents = [
+        AccentInfo(
+            furigana=e["text"],
+            accent_marking_type=e["accent"],
+            length=len(e["text"]),
+        )
+        for e in voiced_span
+    ]
+    # Numerics had no Yahoo furigana to begin with — surface the OJAD reading.
+    display = "".join(e["text"] for e in voiced_span) if is_numeric else yahoo_furigana
+    return WordAccentResult(
+        surface=yahoo_surface,
+        furigana=display,
+        accent=accents,
+        subword=subword,
+    )
+
+
+def _fallback_word(token: Any) -> WordAccentResult:
+    return _build_word_result(token, [])
+
+
 async def align_accent(
     furigana_results: list[Any], ojad_results: list[dict[str, Any]]
 ) -> list[WordAccentResult]:
-    """Align yahoo furigana with OJAD results, return final accent marked result."""
-    final_response_results = []
-    ojad_idx_cnt = 0
+    """Align yahoo furigana with OJAD per-moji entries via global DP.
 
-    logger.debug(f"🔍 [Data Check] First item:{furigana_results[0]}")
+    Returns one WordAccentResult per Yahoo token. Each token consumes a
+    (possibly empty) contiguous span of OJAD entries; the assignment that
+    minimises total mismatch cost wins.
+    """
+    n = len(furigana_results)
+    m = len(ojad_results)
 
-    for i, furigana_result in enumerate(furigana_results):
-        yahoo_furigana = furigana_result.furigana
-        yahoo_surface = furigana_result.surface
+    if n == 0:
+        return []
+    if m == 0:
+        return [_fallback_word(t) for t in furigana_results]
 
-        yahoo_furigana_hira = jaconv.kata2hira(yahoo_furigana)
-        accents: list[AccentInfo] = []
+    # Pre-compute per-token classification and OJAD texts.
+    token_kinds: list[tuple[bool, bool]] = []
+    for t in furigana_results:
+        is_num = bool(numeric_pattern.match(t.surface))
+        is_pct = _is_punct_token(t.furigana, is_num)
+        token_kinds.append((is_num, is_pct))
+    ojad_texts = [e["text"] for e in ojad_results]
 
-        logger.debug(f"Processing Yahoo Word [{i}]: {yahoo_surface} ({yahoo_furigana})")
+    # dp[i][j] = best cost aligning tokens [0..i) to ojad entries [0..j).
+    dp: list[list[float]] = [[_INF] * (m + 1) for _ in range(n + 1)]
+    back: list[list[int]] = [[-1] * (m + 1) for _ in range(n + 1)]
+    dp[0][0] = 0.0
 
-        # Identify if the word is numeric
-        is_numeric = bool(numeric_pattern.match(yahoo_surface))
+    for i in range(n):
+        token = furigana_results[i]
+        is_num, is_pct = token_kinds[i]
+        for j in range(m + 1):
+            base = dp[i][j]
+            if base == _INF:
+                continue
+            k_limit = min(_K_MAX, m - j)
+            for k in range(0, k_limit + 1):
+                cost = _match_cost(token, ojad_texts[j : j + k], is_num, is_pct)
+                if cost == _INF:
+                    continue
+                new_cost = base + cost
+                if new_cost < dp[i + 1][j + k]:
+                    dp[i + 1][j + k] = new_cost
+                    back[i + 1][j + k] = j
 
-        # ignore non-kana/kanji and non-numeric words
-        if (
-            not furigana_result.subword
-            and any(not is_kana_or_kanji(chr) for chr in yahoo_furigana)
-            and not is_numeric
-        ):
-            logger.debug(" -> Skipped (Not Kana/Kanji)")
-            accents.append(
-                AccentInfo(
-                    furigana=yahoo_surface,
-                    accent_marking_type=0,
-                    length=len(yahoo_surface),
-                )
-            )
-            final_response_results.append(
-                WordAccentResult(
-                    furigana=yahoo_furigana, surface=yahoo_surface, accent=accents
-                )
-            )
+    # Pick the best terminal state. Prefer fully consuming OJAD; otherwise
+    # take the cheapest end (trailing empty entries get inherited for free
+    # by the previous token's span since their text contributes nothing to
+    # edit distance).
+    best_j = m
+    best_cost = dp[n][m]
+    if best_cost == _INF:
+        for j in range(m + 1):
+            if dp[n][j] < best_cost:
+                best_cost = dp[n][j]
+                best_j = j
 
-            # Move OJAD index if skipped punctuation
-            if ojad_idx_cnt < len(ojad_results) and jaconv.kata2hira(
-                ojad_results[ojad_idx_cnt]["text"].strip()
-            ) in ["、", "。", ",", "."]:
-                ojad_idx_cnt += 1
-            continue
+    if best_cost == _INF:
+        logger.error(
+            "DP alignment found no valid path (n=%d, m=%d); falling back per token.",
+            n,
+            m,
+        )
+        return [_fallback_word(t) for t in furigana_results]
 
-        # Synchronize OJAD index
-        ojad_idx = ojad_idx_cnt
+    # Backtrack to recover the OJAD span each token consumed.
+    spans: list[tuple[int, int]] = [(0, 0)] * n
+    cur_j = best_j
+    for i in range(n, 0, -1):
+        prev_j = back[i][cur_j]
+        if prev_j < 0:
+            logger.error("DP backtrace broken at i=%d, j=%d", i, cur_j)
+            return [_fallback_word(t) for t in furigana_results]
+        spans[i - 1] = (prev_j, cur_j)
+        cur_j = prev_j
 
-        # Check OJAD boundary
-        if ojad_idx >= len(ojad_results):
-            logger.warning(f" -> OJAD Index Out of Bounds ({ojad_idx})")
-        else:
-            logger.debug(
-                f"-> Comparing Yahoo '{yahoo_furigana_hira}'"
-                f" vs OJAD '{ojad_results[ojad_idx]['text']}'"
-            )
-
-        # Move non-numeric OJAD index to the matching position
-        if not is_numeric:
-            while ojad_idx < len(ojad_results) and not yahoo_furigana_hira.startswith(
-                jaconv.kata2hira(ojad_results[ojad_idx]["text"])
-            ):
-                ojad_idx += 1
-
-        # catch the furigana from Yahoo with OJAD results
-        ojad_furigana = ""
-        temp_accents = []  # Use temp list to avoid partial data
-
-        # Define anchor(next Yahoo furigana) for numeric mode
-        next_yahoo_furigana = None
-        if i + 1 < len(furigana_results):
-            next_yahoo_furigana = jaconv.kata2hira(furigana_results[i + 1].furigana)
-
-        # Backup index
-        temp_ojad_idx = ojad_idx
-
-        # Number mode: grab OJAD until the anchor
-        if is_numeric:
-            while temp_ojad_idx < len(ojad_results):
-                raw_text = ojad_results[temp_ojad_idx]["text"].strip()
-                ojad_text = jaconv.kata2hira(raw_text)
-
-                # Stop if reached the anchor
-                if next_yahoo_furigana and next_yahoo_furigana.startswith(ojad_text):
-                    break
-
-                # Stop if consumed too much data
-                if len(ojad_furigana) > max(len(yahoo_surface) * 4, 12):
-                    logger.warning(
-                        f" -> Numeric consumption exceeded limit '{yahoo_surface}'."
-                    )
-                    break
-
-                ojad_furigana += ojad_text
-                temp_accents.append(
-                    AccentInfo(
-                        furigana=ojad_text,
-                        accent_marking_type=ojad_results[temp_ojad_idx]["accent"],
-                        length=len(ojad_text),
-                    )
-                )
-                temp_ojad_idx += 1
-        # Normal mode: grab OJAD until length match
-        else:
-            while len(ojad_furigana) < len(yahoo_furigana) and temp_ojad_idx < len(
-                ojad_results
-            ):
-                ojad_text = ojad_results[temp_ojad_idx]["text"]
-                ojad_furigana += ojad_text
-                temp_accents.append(
-                    AccentInfo(
-                        furigana=ojad_text,
-                        accent_marking_type=ojad_results[temp_ojad_idx]["accent"],
-                        length=len(ojad_text),
-                    )
-                )
-                temp_ojad_idx += 1
-
-        # Final matching check
-        is_match = False
-        if is_numeric:
-            # Numeric mode: only check if OJAD has furigana grabbed
-            is_match = len(ojad_furigana) > 0
-        else:
-            # Normal mode: check length and content
-            is_match = len(ojad_furigana) == len(yahoo_furigana) and jaconv.kata2hira(
-                ojad_furigana
-            ) == jaconv.kata2hira(yahoo_furigana)
-
-        if is_match:
-            logger.debug(f" -> MATCHED! OJAD: {ojad_furigana}")
-            accents.extend(temp_accents)
-
-            # Build final accent info list
-            accent_info_list = []
-            for idx, accent in enumerate(accents):
-                accent_info_list.append(
-                    AccentInfo(
-                        furigana=accent.furigana,
-                        accent_marking_type=accent.accent_marking_type,
-                        length=accent.length,
-                    )
-                )
-
-            ojad_idx_cnt = temp_ojad_idx  # Update global index
-
-            display_furigana = ojad_furigana if is_numeric else yahoo_furigana
-
-            # Build final response
-            if furigana_result.subword:
-                yahoo_subword = furigana_result.subword
-                logger.debug(
-                    f"[Type Check] yahoo_subword element type: {type(yahoo_subword[0])}"
-                )
-                logger.debug(f"[Data Check] yahoo_subword content: {yahoo_subword}")
-                final_response_results.append(
-                    WordAccentResult(
-                        furigana=display_furigana,
-                        surface=yahoo_surface,
-                        accent=accent_info_list,
-                        subword=[
-                            WordResult(furigana=s.furigana, surface=s.surface)
-                            for s in yahoo_subword
-                        ],
-                    )
-                )
-            else:
-                final_response_results.append(
-                    WordAccentResult(
-                        furigana=display_furigana,
-                        surface=yahoo_surface,
-                        accent=accent_info_list,
-                    )
-                )
-        else:
-            # [ERROR BLOCK]
-            logger.error(
-                "-> MATCH FAILED."
-                f"Yahoo: {yahoo_furigana} vs OJAD Assembly: {ojad_furigana}"
-            )
-
-            # Fallback to Yahoo furigana with no accent info
-            accent_info = AccentInfo(
-                furigana=yahoo_furigana,
-                accent_marking_type=0,
-                length=len(yahoo_furigana),
-            )
-
-            final_response_results.append(
-                WordAccentResult(
-                    furigana=yahoo_furigana,
-                    surface=yahoo_surface,
-                    accent=[accent_info],
-                )
-            )
-
-            # Move OJAD index to next item to avoid infinite loop
-            if ojad_idx_cnt < len(ojad_results):
-                ojad_idx_cnt += 1
-
-    return final_response_results
+    logger.debug("DP alignment cost=%.2f spans=%s", best_cost, spans)
+    return [
+        _build_word_result(furigana_results[i], ojad_results[s:e])
+        for i, (s, e) in enumerate(spans)
+    ]

--- a/api/accent/pipeline.py
+++ b/api/accent/pipeline.py
@@ -1,34 +1,179 @@
 """MarkAccent orchestrator.
 
-Threads the three data-layer modules together:
-  1. `furigana.fetch_furigana` — tokenise + read with Yahoo Furigana
-  2. `ojad.get_ojad_result` — pull per-mora pitch contour from OJAD
-  3. `align.align_accent` — match tokens ↔ OJAD spans → WordAccentResult
+Threads the data-layer modules together and applies the surface-level
+regex override layer on either side of the OJAD alignment:
 
-The route handler in `routes.py` wraps this with FastAPI request handling.
+  1. `furigana.fetch_furigana` — tokenise + read with Yahoo Furigana
+  2. `reading_overrides.apply_furigana_overrides` — fix date / weekday-
+     bracket readings BEFORE alignment so OJAD's numeric-anchor logic
+     doesn't cascade-fail on overridden spans
+  3. `ojad.get_ojad_result` — pull per-mora pitch contour from OJAD
+  4. `align.align_accent` — DP-match tokens ↔ OJAD spans
+  5. `reading_overrides.apply_accent_overrides` — re-apply overrides
+     over (furigana, accent) so the final response stays consistent
+
+Plus pre-/post-processing helpers for URL stripping, non-Japanese
+short-circuit, sentence splitting (used by the streaming endpoint),
+and the streaming chunk-fanout itself.
+
+The route handlers in `routes.py` wrap this with FastAPI request handling.
 """
 
 from __future__ import annotations
 
+import asyncio
+import json
 import logging
+import re
+from typing import Any, AsyncIterator
 
 import httpx
 import neologdn
 
 from api.accent.align import align_accent
 from api.accent.furigana import fetch_furigana
-from api.accent.models import AccentResponse, ErrorInfo
+from api.accent.models import (
+    AccentResponse,
+    ErrorInfo,
+    Request,
+    WordAccentResult,
+)
 from api.accent.ojad import get_ojad_result
+from api.accent.reading_overrides import (
+    apply_accent_overrides,
+    apply_furigana_overrides,
+)
 
 logger = logging.getLogger("api")
 
 
+# Hiragana / katakana / CJK Unified Ideographs (incl. Extension A). A
+# chunk with no chars in this set is treated as pure English / code /
+# markdown / URL — pipeline is skipped entirely and the line is echoed
+# back verbatim so document reconstruction still works.
+_CJK_RE = re.compile(
+    "["
+    "぀-ゟ"  # Hiragana
+    "゠-ヿ"  # Katakana
+    "㐀-䶿"  # CJK Unified Ideographs Extension A
+    "一-鿿"  # CJK Unified Ideographs
+    "]"
+)
+
+# Sentence terminators that close a Japanese clause: kuten (。), full-width
+# question (？), full-width exclamation (！), and full-width period (．).
+# ASCII `.!?` are intentionally excluded — they appear in abbreviations,
+# decimals, and code/identifier fragments that we don't want to split on.
+# A zero-width split (lookbehind) keeps the terminator attached to the
+# preceding sentence so accent prediction still sees the clause boundary.
+_SENTENCE_SPLIT_RE = re.compile("(?<=[。！？．])")
+
+# URLs are stripped before the pipeline runs. OJAD's phrasing scraper
+# produces only noise for Latin punctuation runs, and Yahoo's tokenizer
+# can fragment a URL across several alphabet/symbol tokens — both drag
+# the alignment DP off-rail for the surrounding Japanese. We swap each
+# URL for one fixed-string placeholder (which Yahoo keeps as a single
+# "alphabet" word), run the pipeline, then walk the result and restore
+# the originals in order.
+# URL body stops at whitespace, any Japanese char (so `…はhttps://x.jp/aです`
+# strips just the URL, leaving `です` to be processed), or common quoting
+# punctuation `,()<>[]"'` (so `(https://x.jp)` strips just the URL).
+_URL_RE = re.compile(r"https?://[^\s　-鿿,()<>\[\]\"']+")
+_URL_PLACEHOLDER = "URLPLACEHOLDER"
+
+
+def _has_japanese(text: str) -> bool:
+    """True if `text` contains any hiragana, katakana, or CJK ideograph."""
+    return bool(_CJK_RE.search(text))
+
+
+def _split_sentences(line: str) -> list[str]:
+    """Split a line into sentence-sized chunks for parallel processing.
+
+    OJAD's phrasing module degrades badly on long inputs (a single
+    misaligned mora can cascade across the whole paragraph), and the
+    streaming endpoint can't parallelise within a `\\n`-delimited chunk.
+    Splitting on full-width sentence terminators fixes both: each sentence
+    is short enough for OJAD to handle reliably, and they fan out across
+    the in-flight Semaphore.
+    """
+    return [s for s in _SENTENCE_SPLIT_RE.split(line) if s.strip()]
+
+
+def _strip_urls(text: str) -> tuple[str, list[str]]:
+    """Replace each URL with `_URL_PLACEHOLDER`, returning URLs in order."""
+    urls: list[str] = []
+
+    def repl(m: re.Match[str]) -> str:
+        urls.append(m.group(0))
+        return _URL_PLACEHOLDER
+
+    return _URL_RE.sub(repl, text), urls
+
+
+def _restore_urls(
+    result: list[WordAccentResult], urls: list[str]
+) -> list[WordAccentResult]:
+    """Swap placeholder tokens in `result` back to their original URLs."""
+    if not urls:
+        return result
+    it = iter(urls)
+    out: list[WordAccentResult] = []
+    for w in result:
+        if w.surface == _URL_PLACEHOLDER:
+            url = next(it, None)
+            if url is None:
+                # Placeholder count exceeded URL count: leave the token
+                # untouched. Indicates a Yahoo tokenization surprise; the
+                # output is still readable.
+                out.append(w)
+                continue
+            out.append(
+                WordAccentResult(surface=url, furigana=url, accent=[], subword=[])
+            )
+        else:
+            out.append(w)
+    return out
+
+
 async def process_accent_chunk(text: str, client: httpx.AsyncClient) -> AccentResponse:
-    """Run the full MarkAccent pipeline on a single chunk of text."""
+    """Run the full MarkAccent pipeline on a single chunk of text.
+
+    Shared by `/api/MarkAccent/` (whole input as one chunk) and
+    `/api/MarkAccent/stream/` (one call per `\\n`/sentence-split piece).
+    """
     try:
         query_text = neologdn.normalize(text, tilde="normalize")
 
-        furigana_response = await fetch_furigana(query_text, client)
+        # Strip URLs first so a pure-URL line is detected as non-Japanese
+        # by the language check below and short-circuits the pipeline.
+        stripped_text, urls = _strip_urls(query_text)
+
+        # No hiragana/katakana/kanji outside URLs — passthrough the line
+        # as a single token. Callers reconstructing the document still
+        # see the chunk in the stream; we just skip the Yahoo + OJAD
+        # round-trips entirely.
+        if not _has_japanese(stripped_text):
+            return AccentResponse(
+                status=200,
+                result=[
+                    WordAccentResult(
+                        surface=query_text,
+                        furigana=query_text,
+                        accent=[],
+                        subword=[],
+                    )
+                ],
+                error=None,
+            )
+
+        # Apply furigana overrides BEFORE alignment: many of the overrides
+        # (e.g. "4日"→"よっか", "27日"→"にじゅうしちにち") merge a numeric
+        # surface with the counter into one token whose furigana matches what
+        # OJAD reads as a single phrase. align_accent's numeric-anchor logic
+        # otherwise cascades-fails on these inputs because numeric tokens lack
+        # any Yahoo furigana for OJAD to align against.
+        furigana_response = await fetch_furigana(stripped_text, client)
 
         # Check yahoo furigana response
         if furigana_response.status != 200 or not furigana_response.result:
@@ -39,19 +184,85 @@ async def process_accent_chunk(text: str, client: httpx.AsyncClient) -> AccentRe
                 error=furigana_response.error,
             )
 
-        furigana_results = furigana_response.result
+        furigana_results = apply_furigana_overrides(furigana_response.result)
         logger.debug(f"Yahoo Results Count: {len(furigana_results)}")
 
-        _ojad_surface, ojad_results = await get_ojad_result(query_text, client)
+        _ojad_surface, ojad_results = await get_ojad_result(stripped_text, client)
 
         final_results = await align_accent(furigana_results, ojad_results)
+        final_results = apply_accent_overrides(final_results)
+        final_results = _restore_urls(final_results, urls)
 
         return AccentResponse(status=200, result=final_results)
 
     except Exception as e:
         logger.exception(f"Unexpected error occurred: {text}")
+        # Some httpx exceptions (PoolTimeout, ReadTimeout) have empty
+        # str(); fall back to the type name so the client sees something.
+        detail = str(e) or repr(e) or type(e).__name__
         return AccentResponse(
             status=500,
             result=None,
-            error=ErrorInfo(code=500, message=f"Error: {e}"),
+            error=ErrorInfo(code=500, message=f"Error: {detail}"),
         )
+
+
+# Streaming endpoint: OJAD's u-tokyo backend and (to a lesser extent) Yahoo's
+# furigana API both fall over when hit with 30+ parallel scrapes — the symptom
+# was most chunks of a long document returning empty-string httpx errors. Cap
+# in-flight work so well-behaved inputs still parallelise (a 4-chunk
+# paragraph fans out fully) without hammering the upstream services.
+_STREAM_CONCURRENCY = 4
+
+
+async def stream_accent_chunks(
+    request: Request, client: httpx.AsyncClient
+) -> AsyncIterator[bytes]:
+    """Yield one NDJSON line per (line_idx, sub_idx) chunk in input order.
+
+    Each emitted object carries `{"chunk": line_idx, "subchunk": sub_idx}`:
+    `line_idx` is the original `\\n`-split index (blank lines are dropped from
+    the stream); `sub_idx` distinguishes sentences inside one line. A line
+    with no terminator yields one subchunk with `sub_idx=0`.
+    """
+    # (line_idx, sub_idx, text). Long paragraphs are split into sentence-
+    # sized chunks because OJAD's phrasing predictor degrades on long
+    # inputs and a single misalignment used to cascade across the whole
+    # paragraph. Splitting also fans the work out under the semaphore.
+    chunks: list[tuple[int, int, str]] = []
+    for line_idx, line in enumerate(request.text.split("\n")):
+        if not line.strip():
+            continue
+        for sub_idx, sentence in enumerate(_split_sentences(line)):
+            chunks.append((line_idx, sub_idx, sentence))
+
+    if not chunks:
+        return
+
+    semaphore = asyncio.Semaphore(_STREAM_CONCURRENCY)
+
+    async def run_chunk(line: str) -> AccentResponse:
+        async with semaphore:
+            return await process_accent_chunk(line, client)
+
+    tasks = [asyncio.create_task(run_chunk(text)) for _, _, text in chunks]
+    # Yield in input order so the client renders chunks monotonically.
+    for (chunk_idx, sub_idx, _text), task in zip(chunks, tasks):
+        try:
+            resp = await task
+            payload: dict[str, Any] = {
+                "chunk": chunk_idx,
+                "subchunk": sub_idx,
+                **resp.model_dump(),
+            }
+        except Exception as exc:
+            logger.exception(f"Streaming chunk {chunk_idx}.{sub_idx} failed")
+            detail = str(exc) or repr(exc) or type(exc).__name__
+            payload = {
+                "chunk": chunk_idx,
+                "subchunk": sub_idx,
+                "status": 500,
+                "result": None,
+                "error": {"code": 500, "message": f"Error: {detail}"},
+            }
+        yield (json.dumps(payload, ensure_ascii=False) + "\n").encode("utf-8")

--- a/api/accent/reading_overrides.py
+++ b/api/accent/reading_overrides.py
@@ -1,0 +1,457 @@
+"""
+Predefined regex override layer for Yahoo Furigana / Suzuki-kun (OJAD) accent
+results.
+
+Yahoo's furigana service is context-blind — it gets common date and weekday-
+bracket readings wrong (e.g. "5日" → にち instead of いつか, "(土)" → つち
+instead of ど). We post-process Yahoo's tokenised response with a list of
+`FuriganaOverride` entries: each entry is a regex against the concatenated
+surface text, plus the replacement tokens that should appear instead.
+
+The same overrides are applied a second time after OJAD alignment, replacing
+both furigana and accent in one go.
+
+Patterns are written with character classes that accept half-width, full-width,
+and kanji-numeral variants of the same surface, so "3月5日(土)" / "３月５日（土）"
+/ "三月五日（土）" all trigger the same overrides.
+
+If a match doesn't fall on Yahoo's token boundaries we log a warning and leave
+the match alone — Yahoo's result passes through unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Callable, TypeVar
+
+from api.accent.models import AccentInfo, WordAccentResult, WordResult
+
+logger = logging.getLogger("api")
+
+
+@dataclass(frozen=True)
+class ReplacementToken:
+    """One token in an override's replacement list.
+
+    `surface=None` means: inherit the surface from the matched substring (full
+    text for a single-token replacement, or per-position when the replacement
+    count equals the match length — see _resolve_surface).
+
+    `furigana=None` means: echo the resolved surface (useful for non-kana
+    positions like brackets, mirroring Yahoo's own fallback in
+    `api/accent/furigana.py`).
+
+    `accent` is a per-moji sequence of (kana, accent_marking_type) — 0=none,
+    1=heiban, 2=fall — matching the existing AccentInfo schema. Empty tuple →
+    fall back to a single accent_marking_type=0 entry covering the whole
+    furigana.
+    """
+
+    furigana: str | None = None
+    surface: str | None = None
+    accent: tuple[tuple[str, int], ...] = ()
+
+
+@dataclass(frozen=True)
+class FuriganaOverride:
+    pattern: re.Pattern[str]
+    replacements: tuple[ReplacementToken, ...]
+    description: str = ""
+
+
+# accent_marking_type values (mirror AccentInfo)
+_NONE, _HEIBAN, _FALL = 0, 1, 2
+
+# Numeric / kanji-numeral class used in lookbehind & lookahead so partial
+# matches don't fire (e.g. avoid "11日" → "1日" or "二十五日" → "五日").
+_DIGIT_CLASS = r"\d一二三四五六七八九十百千"
+_NOT_NUM_BEHIND = rf"(?<![{_DIGIT_CLASS}])"
+_NOT_NUM_AHEAD = rf"(?![{_DIGIT_CLASS}])"
+
+
+def _moji_seq(text: str, t: int = _HEIBAN) -> tuple[tuple[str, int], ...]:
+    return tuple((c, t) for c in text)
+
+
+def _atamadaka_seq(text: str) -> tuple[tuple[str, int], ...]:
+    if not text:
+        return ()
+    return ((text[0], _FALL),) + tuple((c, _HEIBAN) for c in text[1:])
+
+
+# Numeric variant helpers: keep N-prefixed patterns (N日, N日間, N歳) from
+# repeating the (arabic, fullwidth, kanji) triple per row.
+
+_FULLWIDTH_TRANS = str.maketrans("0123456789", "０１２３４５６７８９")
+
+
+def _int_to_kanji(n: int) -> str:
+    """Traditional kanji numeral for n (1-99).
+
+    Examples: 1→'一', 10→'十', 14→'十四', 20→'二十', 24→'二十四', 31→'三十一'.
+    """
+    if not 1 <= n <= 99:
+        raise ValueError(f"_int_to_kanji supports 1-99, got {n}")
+    digits = "〇一二三四五六七八九"
+    tens, ones = divmod(n, 10)
+    if tens == 0:
+        return digits[ones]
+    tens_part = "十" if tens == 1 else digits[tens] + "十"
+    return tens_part + (digits[ones] if ones else "")
+
+
+def _numeric_pattern(n: int) -> str:
+    """Regex alternation matching n in arabic / full-width / traditional-kanji.
+
+    Alternatives are emitted longest-first so multi-char kanji forms like
+    '二十四' aren't shadowed by their numeric-form prefixes.
+    """
+    arabic = str(n)
+    fullwidth = arabic.translate(_FULLWIDTH_TRANS)
+    kanji = _int_to_kanji(n)
+    variants = sorted({arabic, fullwidth, kanji}, key=len, reverse=True)
+    return "(?:" + "|".join(variants) + ")"
+
+
+def _day_of_week_overrides() -> list[FuriganaOverride]:
+    readings: list[tuple[str, str]] = [
+        ("月", "げつ"),
+        ("火", "か"),
+        ("水", "すい"),
+        ("木", "もく"),
+        ("金", "きん"),
+        ("土", "ど"),
+        ("日", "にち"),
+    ]
+    out: list[FuriganaOverride] = []
+    for kanji, reading in readings:
+        # surface=None on all three lets _resolve_surface inherit per-position
+        # from the matched substring, preserving half-width vs full-width
+        # brackets in the input. furigana=None on the brackets echoes their
+        # surface (Yahoo also returns the bracket char as its own furigana).
+        out.append(
+            FuriganaOverride(
+                pattern=re.compile(rf"[(（]{kanji}[)）]"),
+                replacements=(
+                    ReplacementToken(),  # left bracket: both inherit
+                    ReplacementToken(furigana=reading, accent=_moji_seq(reading)),
+                    ReplacementToken(),  # right bracket: both inherit
+                ),
+                description=f"曜日 ({kanji})",
+            )
+        )
+    return out
+
+
+def _date_overrides() -> list[FuriganaOverride]:
+    # 1-10日, 14日, 20日, 24日 are irregular (ついたち, ふつか, ..., はつか).
+    # 11-31日 are regular (じゅういちにち etc.) but Yahoo often returns the
+    # literal digits as their own "furigana" for numeric tokens; the accent
+    # endpoint's align_accent also frequently misaligns numeric spans.
+    # Listing every day-of-month here gives both endpoints a deterministic
+    # reading + accent for any date.
+    #
+    # Only 1日 (ついたち) is atamadaka — the rest sit in heiban-style.
+    readings: list[tuple[int, str, tuple[tuple[str, int], ...]]] = [
+        (1, "ついたち", _atamadaka_seq("ついたち")),
+        (2, "ふつか", _moji_seq("ふつか")),
+        (3, "みっか", _moji_seq("みっか")),
+        (4, "よっか", _moji_seq("よっか")),
+        (5, "いつか", _moji_seq("いつか")),
+        (6, "むいか", _moji_seq("むいか")),
+        (7, "なのか", _moji_seq("なのか")),
+        (8, "ようか", _moji_seq("ようか")),
+        (9, "ここのか", _moji_seq("ここのか")),
+        (10, "とおか", _moji_seq("とおか")),
+        (11, "じゅういちにち", _moji_seq("じゅういちにち")),
+        (12, "じゅうににち", _moji_seq("じゅうににち")),
+        (13, "じゅうさんにち", _moji_seq("じゅうさんにち")),
+        (14, "じゅうよっか", _moji_seq("じゅうよっか")),
+        (15, "じゅうごにち", _moji_seq("じゅうごにち")),
+        (16, "じゅうろくにち", _moji_seq("じゅうろくにち")),
+        (17, "じゅうしちにち", _moji_seq("じゅうしちにち")),
+        (18, "じゅうはちにち", _moji_seq("じゅうはちにち")),
+        (19, "じゅうくにち", _moji_seq("じゅうくにち")),
+        (20, "はつか", _moji_seq("はつか")),
+        (21, "にじゅういちにち", _moji_seq("にじゅういちにち")),
+        (22, "にじゅうににち", _moji_seq("にじゅうににち")),
+        (23, "にじゅうさんにち", _moji_seq("にじゅうさんにち")),
+        (24, "にじゅうよっか", _moji_seq("にじゅうよっか")),
+        (25, "にじゅうごにち", _moji_seq("にじゅうごにち")),
+        (26, "にじゅうろくにち", _moji_seq("にじゅうろくにち")),
+        (27, "にじゅうしちにち", _moji_seq("にじゅうしちにち")),
+        (28, "にじゅうはちにち", _moji_seq("にじゅうはちにち")),
+        (29, "にじゅうくにち", _moji_seq("にじゅうくにち")),
+        (30, "さんじゅうにち", _moji_seq("さんじゅうにち")),
+        (31, "さんじゅういちにち", _moji_seq("さんじゅういちにち")),
+    ]
+    return [
+        FuriganaOverride(
+            pattern=re.compile(
+                rf"{_NOT_NUM_BEHIND}{_numeric_pattern(n)}日{_NOT_NUM_AHEAD}"
+            ),
+            replacements=(ReplacementToken(furigana=furigana, accent=accent),),
+            description=f"特殊日期 {n}日",
+        )
+        for n, furigana, accent in readings
+    ]
+
+
+def _duration_overrides() -> list[FuriganaOverride]:
+    """N日間 (counter for days as a duration) expansions.
+
+    Yahoo tokenises e.g. `1日間` as [`1`, `日間`] and gives the numeric
+    token no furigana (its result is just the literal digit), so the
+    furigana endpoint surfaces unreadable output like `1にちかん`. We
+    override the full N日間 span so the user sees a complete reading.
+
+    Most readings are the existing date reading + `かん`, with two
+    intentional deviations:
+    - `1日間` → `いちにちかん` (NOT `ついたちかん` — the 1st-of-month
+      reading is impossible when 1日 is a duration).
+    - `7日間` → `しちにちかん` (preferred in modern technical writing
+      over the older `なのかかん`).
+    """
+    readings: list[tuple[int, str]] = [
+        (1, "いちにちかん"),
+        (2, "ふつかかん"),
+        (3, "みっかかん"),
+        (4, "よっかかん"),
+        (5, "いつかかん"),
+        (6, "むいかかん"),
+        (7, "しちにちかん"),
+        (8, "ようかかん"),
+        (9, "ここのかかん"),
+        (10, "とおかかん"),
+        (11, "じゅういちにちかん"),
+        (12, "じゅうににちかん"),
+        (13, "じゅうさんにちかん"),
+        (14, "じゅうよっかかん"),
+        (15, "じゅうごにちかん"),
+        (16, "じゅうろくにちかん"),
+        (17, "じゅうしちにちかん"),
+        (18, "じゅうはちにちかん"),
+        (19, "じゅうくにちかん"),
+        (20, "はつかかん"),
+        (21, "にじゅういちにちかん"),
+        (22, "にじゅうににちかん"),
+        (23, "にじゅうさんにちかん"),
+        (24, "にじゅうよっかかん"),
+        (25, "にじゅうごにちかん"),
+        (26, "にじゅうろくにちかん"),
+        (27, "にじゅうしちにちかん"),
+        (28, "にじゅうはちにちかん"),
+        (29, "にじゅうくにちかん"),
+        (30, "さんじゅうにちかん"),
+        (31, "さんじゅういちにちかん"),
+    ]
+    return [
+        FuriganaOverride(
+            pattern=re.compile(rf"{_NOT_NUM_BEHIND}{_numeric_pattern(n)}日間"),
+            replacements=(
+                ReplacementToken(furigana=furigana, accent=_moji_seq(furigana)),
+            ),
+            description=f"期間 {n}日間",
+        )
+        for n, furigana in readings
+    ]
+
+
+def _age_overrides() -> list[FuriganaOverride]:
+    """Irregular age readings.
+
+    20歳 / 二十歳 (and the casual 才 variant) → はたち, not the regular
+    にじゅっさい. Only 20 is irregular for ages; the rest are systematic
+    so we don't need a 1-99 table here.
+    """
+    return [
+        FuriganaOverride(
+            pattern=re.compile(
+                rf"{_NOT_NUM_BEHIND}{_numeric_pattern(20)}[歳才]{_NOT_NUM_AHEAD}"
+            ),
+            replacements=(
+                ReplacementToken(furigana="はたち", accent=_atamadaka_seq("はたち")),
+            ),
+            description="20歳 → はたち",
+        ),
+    ]
+
+
+# Order matters: _collect_matches breaks ties on (start, -length) and
+# discards anything overlapping an earlier pick. `N日間` (3-4 chars) is
+# strictly longer than `N日` at the same start, so duration entries
+# automatically win over date entries for the same N when 間 follows.
+OVERRIDES: list[FuriganaOverride] = (
+    _day_of_week_overrides()
+    + _duration_overrides()
+    + _date_overrides()
+    + _age_overrides()
+)
+
+
+# ---------- Apply algorithm (shared between furigana & accent variants) ----------
+
+
+@dataclass
+class _Match:
+    start: int
+    end: int
+    override: FuriganaOverride
+
+
+def _collect_matches(text: str) -> list[_Match]:
+    """Run every override's regex and return non-overlapping matches.
+
+    Earlier start wins; ties broken by longer match.
+    """
+    raw: list[_Match] = []
+    for ov in OVERRIDES:
+        for rm in ov.pattern.finditer(text):
+            raw.append(_Match(start=rm.start(), end=rm.end(), override=ov))
+    raw.sort(key=lambda x: (x.start, -(x.end - x.start)))
+    chosen: list[_Match] = []
+    last_end = 0
+    for cm in raw:
+        if cm.start < last_end:
+            continue
+        chosen.append(cm)
+        last_end = cm.end
+    return chosen
+
+
+def _resolve_surface(
+    replacements: tuple[ReplacementToken, ...],
+    position: int,
+    matched_text: str,
+) -> str:
+    """Pick the surface for a replacement token.
+
+    - explicit `surface` always wins;
+    - single-token replacement with `surface=None` → use full matched substring;
+    - multi-token replacement with `surface=None`, where the number of tokens
+      equals the matched span length, → inherit per-position from the matched
+      substring (this preserves half/full-width brackets, kanji vs arabic
+      digits, etc. that the regex character classes accepted);
+    - otherwise → warn and fall back to the furigana string.
+    """
+    rt = replacements[position]
+    if rt.surface is not None:
+        return rt.surface
+    n = len(replacements)
+    if n == 1:
+        return matched_text
+    if n == len(matched_text):
+        return matched_text[position]
+    fallback = rt.furigana if rt.furigana is not None else matched_text
+    logger.warning(
+        "Override replacement at position %d missing explicit `surface` and "
+        "cannot inherit (n_replacements=%d, match_len=%d); falling back to %r",
+        position,
+        n,
+        len(matched_text),
+        fallback,
+    )
+    return fallback
+
+
+T = TypeVar("T")
+
+
+def _apply(
+    words: list[T],
+    surface_of: Callable[[T], str],
+    build: Callable[[tuple[ReplacementToken, ...], int, str], T],
+) -> list[T]:
+    if not words:
+        return list(words)
+
+    surfaces = [surface_of(w) for w in words]
+    full_text = "".join(surfaces)
+
+    # offsets[i] = char position of token i's start; offsets[-1] = total length
+    offsets: list[int] = [0]
+    for s in surfaces:
+        offsets.append(offsets[-1] + len(s))
+    boundary_to_index = {off: i for i, off in enumerate(offsets)}
+
+    matches = _collect_matches(full_text)
+    if not matches:
+        return list(words)
+
+    out: list[T] = []
+    cursor = 0
+    for m in matches:
+        start_idx = boundary_to_index.get(m.start)
+        end_idx = boundary_to_index.get(m.end)
+        if start_idx is None or end_idx is None:
+            logger.warning(
+                "Override %r match at [%d, %d) does not align with Yahoo token "
+                "boundaries — skipping",
+                m.override.description or m.override.pattern.pattern,
+                m.start,
+                m.end,
+            )
+            continue
+        if start_idx < cursor:
+            # earlier non-overlapping match already consumed this region
+            continue
+        while cursor < start_idx:
+            out.append(words[cursor])
+            cursor += 1
+        matched_text = full_text[m.start : m.end]
+        replacements = m.override.replacements
+        for idx in range(len(replacements)):
+            out.append(build(replacements, idx, matched_text))
+        cursor = end_idx
+    while cursor < len(words):
+        out.append(words[cursor])
+        cursor += 1
+    return out
+
+
+def _resolve_furigana(rt: ReplacementToken, surface: str) -> str:
+    return rt.furigana if rt.furigana is not None else surface
+
+
+def apply_furigana_overrides(words: list[WordResult]) -> list[WordResult]:
+    """Post-process Yahoo Furigana results, replacing matched spans."""
+
+    def build(
+        repls: tuple[ReplacementToken, ...], pos: int, matched: str
+    ) -> WordResult:
+        rt = repls[pos]
+        surface = _resolve_surface(repls, pos, matched)
+        return WordResult(surface=surface, furigana=_resolve_furigana(rt, surface))
+
+    return _apply(words, lambda w: w.surface, build)
+
+
+def apply_accent_overrides(
+    words: list[WordAccentResult],
+) -> list[WordAccentResult]:
+    """Post-process accent-aligned results, replacing both furigana and accent."""
+
+    def build(
+        repls: tuple[ReplacementToken, ...], pos: int, matched: str
+    ) -> WordAccentResult:
+        rt = repls[pos]
+        surface = _resolve_surface(repls, pos, matched)
+        furigana = _resolve_furigana(rt, surface)
+        if rt.accent:
+            accent = [
+                AccentInfo(furigana=moji, accent_marking_type=t, length=len(moji))
+                for moji, t in rt.accent
+            ]
+        else:
+            accent = [
+                AccentInfo(
+                    furigana=furigana,
+                    accent_marking_type=_NONE,
+                    length=len(furigana),
+                )
+            ]
+        return WordAccentResult(surface=surface, furigana=furigana, accent=accent)
+
+    return _apply(words, lambda w: w.surface, build)

--- a/api/accent/routes.py
+++ b/api/accent/routes.py
@@ -1,8 +1,9 @@
 """FastAPI routers for MarkAccent and MarkFurigana.
 
 Each endpoint is a thin wrapper around its data layer:
-  - /MarkFurigana/  → `furigana.fetch_furigana`
-  - /MarkAccent/    → `pipeline.process_accent_chunk`
+  - /MarkFurigana/        → `furigana.fetch_furigana`
+  - /MarkAccent/          → `pipeline.process_accent_chunk`
+  - /MarkAccent/stream/   → `pipeline.stream_accent_chunks` (NDJSON)
 
 Two separate routers (rather than one shared one) keep the OpenAPI
 tagging clean and let main.py register each with its own
@@ -15,10 +16,11 @@ import logging
 
 import httpx
 from fastapi import APIRouter, Depends
+from fastapi.responses import StreamingResponse
 
 from api.accent.furigana import fetch_furigana
 from api.accent.models import AccentResponse, FuriganaResponse, Request
-from api.accent.pipeline import process_accent_chunk
+from api.accent.pipeline import process_accent_chunk, stream_accent_chunks
 from api.dependencies import get_http_client
 
 logger = logging.getLogger("api")
@@ -57,3 +59,19 @@ async def mark_accent(
     """Receive POST request, return an AccentResponse object."""
     logger.info(f"[API] Received Request Text: {request.text}")
     return await process_accent_chunk(request.text, client)
+
+
+@accent_router.post("/MarkAccent/stream/", tags=["MarkAccent"])
+async def mark_accent_stream(
+    request: Request,
+    client: httpx.AsyncClient = Depends(get_http_client),
+) -> StreamingResponse:
+    """Split the input on `\\n` (line) and then on full-width sentence
+    terminators (sub-chunk), process each piece in parallel under a bounded
+    semaphore, and stream one NDJSON line per piece in input order.
+    """
+    logger.info(f"[API] Received streaming request: {request.text!r}")
+    return StreamingResponse(
+        stream_accent_chunks(request, client),
+        media_type="application/x-ndjson",
+    )

--- a/main.py
+++ b/main.py
@@ -1,8 +1,8 @@
 """
-An API interface that provide two functionalities
-(1) Accent Marker   (/api/MarkAccent/)
+An API interface that provide the following functionalities
+(1) Accent Marker   (/api/MarkAccent/  +  /api/MarkAccent/stream/)
 (2) Furigana Marker (/api/MarkFurigana/)
-(3) Usage Query    (/api/UsageQuery/)
+(3) Usage Query     (/api/UsageQuery/)
 (4) Dictionary Query (/api/DictQuery/)
 (5) Sentence Query  (/api/SentenceQuery/)
 """

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# Send a test text to the local API and print one
+# (surface|furigana|accent_marking_type) line per moji.
+#
+# Usage:
+#   ./test.sh                                  # default text on MarkAccent
+#   ./test.sh "三月五日（土）"                  # custom text
+#   PORT=8000 ./test.sh                        # different port
+#   ENDPOINT=MarkFurigana ./test.sh            # furigana endpoint (accent="-")
+#   STREAM=1 ./test.sh $'first\nsecond'        # streaming endpoint, NDJSON
+
+set -euo pipefail
+
+TEXT="${1:-3月5日(土)}"
+PORT="${PORT:-8000}"
+ENDPOINT="${ENDPOINT:-MarkAccent}"
+STREAM="${STREAM:-0}"
+
+if [[ "$STREAM" == "1" ]]; then
+  URL="http://127.0.0.1:${PORT}/api/${ENDPOINT}/stream/"
+else
+  URL="http://127.0.0.1:${PORT}/api/${ENDPOINT}/"
+fi
+
+PAYLOAD=$(uv run python -c \
+  'import json, sys; print(json.dumps({"text": sys.argv[1]}))' "$TEXT")
+
+if [[ "$STREAM" == "1" ]]; then
+  # Streaming mode: pipe NDJSON straight to a per-line viewer.
+  read -r -d '' STREAM_VIEWER <<'PY' || true
+import sys, json
+
+seen = 0
+for raw in sys.stdin:
+    raw = raw.strip()
+    if not raw:
+        continue
+    seen += 1
+    d = json.loads(raw)
+    chunk = d["chunk"]
+    sub = d.get("subchunk", 0)
+    status = d["status"]
+    err = d.get("error")
+    result = d.get("result") or []
+    print(f"--- chunk {chunk}.{sub}  status={status}  words={len(result)} ---")
+    if err:
+        print(f"  ERROR: {err}")
+        continue
+    for w in result:
+        surface = w["surface"]
+        accents = w.get("accent") or []
+        if not accents:
+            print(f"  ({surface}|{w['furigana']}|-)")
+            continue
+        for a in accents:
+            moji = a["furigana"]
+            t = a["accent_marking_type"]
+            print(f"  ({surface}|{moji}|{t})")
+if seen == 0:
+    print("(empty stream — no non-blank input lines)")
+PY
+
+  # -N disables curl's output buffering so each NDJSON line lands in the
+  # viewer as soon as the server flushes it.
+  curl -sN -X POST "$URL" \
+    -H 'Content-Type: application/json' \
+    --data-raw "$PAYLOAD" \
+  | uv run python -c "$STREAM_VIEWER"
+  exit 0
+fi
+
+# Non-streaming mode (original behaviour).
+HTTP_STATUS=$(curl -s -o /tmp/test_sh_body.$$ -w '%{http_code}' \
+  -X POST "$URL" -H 'Content-Type: application/json' --data-raw "$PAYLOAD" \
+  || true)
+if [[ "$HTTP_STATUS" != "200" || ! -s /tmp/test_sh_body.$$ ]]; then
+  echo "Request to $URL failed (HTTP ${HTTP_STATUS:-no-response})." >&2
+  echo "Is the server running? Try: uv run uvicorn main:app --host 127.0.0.1 --port ${PORT}" >&2
+  rm -f /tmp/test_sh_body.$$
+  exit 1
+fi
+
+read -r -d '' FORMAT_SCRIPT <<'PY' || true
+import json, sys
+
+data = json.load(sys.stdin)
+if data.get("status") != 200 or not data.get("result"):
+    print("ERROR:", data.get("error") or data)
+    sys.exit(1)
+
+for w in data["result"]:
+    surface = w["surface"]
+    accents = w.get("accent") or []
+    if not accents:
+        print(f"({surface}|{w['furigana']}|-)")
+        continue
+    for a in accents:
+        print(f"({surface}|{a['furigana']}|{a['accent_marking_type']})")
+PY
+
+uv run python -c "$FORMAT_SCRIPT" < /tmp/test_sh_body.$$
+rm -f /tmp/test_sh_body.$$


### PR DESCRIPTION
<!-- 請先閱讀我們手冊的 [How to PR](https://hackmd.io/@sessatakuma/pr_template#How-to-PR) 章節 -->
<!-- 記得修改PR標題成 conventional commit 之標題格式  -->

### 目的
針對 Yahoo Furigana / OJAD 在日期、星期、期間、年齡等 context-sensitive 讀音上的錯誤，加上一層 regex-based override；同時把 `/api/MarkAccent/` 升級成可串流的版本，並把 furigana endpoint 合併進來統一維護。

> Base = `refactor/accent-package` (#52)。等 #52 merge 後改 base 到 `main`。

### Rebase 更新 (2026-05-21)

Rebased onto PR #52 (`refactor/accent-package`)。原本一坨堆在 `api/accent_marker.py` 的內容，已依照新的 package layout 重新分布：

- regex override engine → `api/accent/reading_overrides.py`
- streaming endpoint (`/MarkAccent/stream/`) → `api/accent/routes.py` + helper in `api/accent/pipeline.py`
- DP aligner upgrade (greedy → Needleman-Wunsch with rendaku fold) → `api/accent/align.py`
- URL / non-JP preprocessing + sentence splitting → `api/accent/pipeline.py`

3 commits on top of `refactor/accent-package`:

```
801aff4 feat(accent): add /MarkAccent/stream/ NDJSON endpoint + dev helpers
27d9da9 feat(accent): regex reading-override layer + URL/non-JP preprocessing
d659feb refactor(accent): replace greedy aligner with Needleman-Wunsch DP + rendaku fold
```

Previous tip `b87ebe9` reachable via reflog if needed. Old base (`feat/docker-compose`) replaced with `refactor/accent-package`.

**Verified locally:**
- `ruff format --check`, `ruff check`, `mypy` all pass on 9 source files
- `3月5日(土)` → date override fires (`いつか`), weekday bracket override fires (`ど`)
- `/MarkAccent/stream/` returns NDJSON, one object per line

下方原始說明仍然描述設計意圖（演算法、規則表、串流分段策略），檔案路徑請對照上方新 layout。

### 方法／實作說明

#### 1. Reading override 層（now `api/accent/reading_overrides.py`）
Yahoo Furigana 對日期／星期沒有上下文判斷（`5日` → にち、`(土)` → つち），OJAD 對數字 token 也常 misalign。新增一層套在 Yahoo 之後、OJAD alignment 之後各跑一次的 regex override：

- **資料結構**：`FuriganaOverride(pattern, replacements, description)` + `ReplacementToken(furigana, surface, accent)`，引擎完全 generic，跟領域無關。
- **比對演算法**：`_collect_matches` 收集所有 hit 後依 `(start, -length)` 排序、丟掉 overlap；同位置「較長 match 勝出」自然讓 `N日間` (3-4 chars) 蓋過 `N日` (2-3 chars)。
- **boundary check**：match 一定要落在 Yahoo token 邊界上，沒對齊就 warn 並跳過 — 不會弄壞 Yahoo 原本的 token list。

涵蓋規則：
- **日期 1-31日**（`_date_overrides`）：1-10日、14日、20日、24日 給正確的 irregular 讀音（ついたち、ふつか、…、はつか）；11-31日 給確定的 regular 讀音，避開 Yahoo 對數字 token 不回 furigana 的問題。
- **星期 (月)-(日)**（`_day_of_week_overrides`）：括號內單漢字星期。
- **期間 1-31日間**（`_duration_overrides`）：避免 Yahoo 把 `1日間` 切成 `[1, 日間]` 後 surface 變 `1にちかん`。`7日間` 採 しちにちかん（現代偏好），`1日間` 採 いちにちかん（不能跟 ついたち 撞）。
- **年齡 20歳/才**（`_age_overrides`）：はたち（頭高）。

#### 2. 數字變體 helper
`_int_to_kanji(n)` + `_numeric_pattern(n)` 把 (arabic, full-width, kanji) 三種寫法從整數自動展開，新增 N-prefixed 規則只需要寫 `(n, 讀音)`，不用再手寫 `(?:漢字|全形|半形)` alternation。同時 honor `feedback_japanese_text_variants` — 任何 JP regex 都會 cover 三種變體。

#### 3. 對齊演算法升級（now `api/accent/align.py`）
- **Needleman-Wunsch DP `align_accent`** 取代原本的 greedy alignment — 解決長段落裡一個 misalignment 連鎖污染後續所有 token 的問題。
- **Rendaku-tolerant**：DP cost 容許 が↔か、だ↔た 等濁音／清音互換。
- **長音字不再被跳過**：原本 alignment 對「動画」、「映像」這類有長音的詞會直接 skip，現在能正確對到。
- **furigana override 在 OJAD alignment 之前套用**，讓 OJAD 看到的是已修正的 token。

#### 4. 串流 endpoint `/api/MarkAccent/stream/`
- 依 `\n` 與全形句點 (`。`／`！`／`？`) 切 chunk，每段獨立打 Yahoo + OJAD。
- NDJSON 回傳，一個 chunk 一行 `{"chunk": N, "subchunk": M, "status": ..., "result": [...], "error": ...}`。
- 非日文段落、純 URL／純標點段落會被 skip 而不打外部 API。
- 單一 chunk 失敗不會中斷整個 stream，會以 `status=500` 回該 chunk 然後繼續。
- 長段落 stability fix：DP table 大小、subchunk 切點都有對應的 safety bound。

#### 5. furigana → accent 合併
- 刪掉舊的 `api/furigana_marker.py` 與 `/api/MarkFurigana/` route。所有用 furigana 的內部呼叫改走 `_fetch_yahoo_raw + apply_furigana_overrides`（now under `api/accent/`）。
- `_fetch_yahoo_raw` 改成回傳 `list[WordResult] | _YahooFetchError`（frozen dataclass sentinel），避免外層 try/except 把 408 timeout 吞成 opaque 500。
- override module 從 `config/furigana_overrides.py` → `api/accent/reading_overrides.py`（git mv，保留歷史） — `config/` 只該放真 config，不該放轉換邏輯。

#### 6. 開發工具
- `test.sh`：local API smoke test，支援 `STREAM=1 ./test.sh` 跑串流，per-line `(surface|furigana|accent_marking_type)` 輸出。
- `.gitignore`：把 `data/` 跟 `output/` 排除掉，避免 test fixture 進 git。

### Diff 範圍
3 commits ahead of `refactor/accent-package` (#52)，主要動到：
- `api/accent/align.py`（DP align + rendaku fold）
- `api/accent/reading_overrides.py`（新檔，從 `config/furigana_overrides.py` rename + 大幅擴充）
- `api/accent/pipeline.py`（streaming chunk orchestrator、URL/non-JP preprocess）
- `api/accent/routes.py`（`/MarkAccent/stream/` route）
- `test.sh`（新增）

### 關聯
- Implements #45 (Rule-based post accent correction) — override 層即此 issue 描述的 rule-based correction 機制，套用在 Yahoo furigana 與 OJAD accent 兩條 path 上。
- 疊在 #52 (`refactor/accent-package`) 上。
- 跟 #44（numeric token furigana）方向一致 — 此 PR 用 override 層提供更廣的 deterministic fallback。

### 附註
- Draft 狀態：streaming endpoint 的 stability fix 跟 override 表都還有可能再迭代（例如 `日後`／`日前`／`日中` 等期間訊號目前刻意暫不處理，等實際 case 出現再加）。
- `apply_*_overrides` 已經涵蓋 furigana 跟 accent 兩條 path，新加 rule 不用動 pipeline 主流程。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
