### PR TITLE
feat(accent): POS-driven ます/たい patches via Yahoo MA-UniDic

### DIFF
--- a/api/accent_marker.py
+++ b/api/accent_marker.py
@@ -21,6 +21,7 @@ from pydantic import BaseModel, Field
 from api.dependencies import get_http_client
 from api.reading_overrides import (
     apply_accent_overrides,
+    apply_accent_patches,
     apply_furigana_overrides,
 )
 from config.settings import YAHOO_API_KEY
@@ -147,23 +148,46 @@ class ErrorInfo(BaseModel):
 
 
 class WordResult(BaseModel):
-    """Class representing a single word from Yahoo's furigana service.
+    """Class representing a single word from Yahoo's MA (morphological
+    analysis) service.
 
-    Defined here (and not in a separate module) because the only consumer of
-    the raw Yahoo tokenisation is the accent pipeline below — there is no
-    public furigana endpoint.
+    `furigana` holds Yahoo MA's `reading` field (kana). The five POS metadata
+    fields are `None` when a token is constructed by override replacements
+    (i.e. has no MA backing) — see `apply_furigana_overrides`.
     """
 
-    furigana: str = Field(description="Furigana of given kana and kanji")
+    furigana: str = Field(description="Reading of the surface in kana")
     surface: str = Field(description="The (partial of) original query text")
     subword: list["WordResult"] = Field(
         default_factory=list,
         description=(
-            "A list contains more details when a word contains both kanji "
-            "and kana. Each elements in subword follow the same schema as "
-            "this parent object (containing `furigana`, `surface`, and "
-            "`subword`)."
+            "Reserved for compatibility — Yahoo MA does not emit subwords. "
+            "Kept on the model so override-constructed tokens still satisfy "
+            "the old schema."
         ),
+    )
+    base: str | None = Field(
+        default=None,
+        description="Lemma / base form from Yahoo MA (e.g. 食べる for 食べ)",
+    )
+    pos: str | None = Field(
+        default=None,
+        description="Part-of-speech tag from Yahoo MA (e.g. 動詞, 名詞, 接尾辞)",
+    )
+    pos1: str | None = Field(
+        default=None,
+        description=(
+            "POS sub-category from Yahoo MA (e.g. 動詞性接尾辞 for ます, "
+            "形容詞性述語接尾辞 for たい)"
+        ),
+    )
+    conjugation_type: str | None = Field(
+        default=None,
+        description="Conjugation type from Yahoo MA (活用型)",
+    )
+    conjugation_form: str | None = Field(
+        default=None,
+        description="Conjugation form from Yahoo MA (活用形)",
     )
 
 
@@ -178,7 +202,12 @@ class AccentInfo(BaseModel):
 
 
 class WordAccentResult(BaseModel):
-    """Class representing a single word result object"""
+    """Class representing a single word result object.
+
+    The POS metadata fields mirror `WordResult` and are passed through
+    `align_accent` so downstream patches (see `apply_accent_patches` in
+    `reading_overrides`) can branch on POS / conjugation.
+    """
 
     furigana: str = Field(description="Furigana of given kana and kanji")
     surface: str = Field(description="The (partial of) original query text")
@@ -187,6 +216,17 @@ class WordAccentResult(BaseModel):
         default_factory=list,
         description="""A list contains more details when a \
         word contains both kanji and kana.""",
+    )
+    base: str | None = Field(default=None, description="Lemma from Yahoo MA")
+    pos: str | None = Field(default=None, description="POS tag from Yahoo MA")
+    pos1: str | None = Field(
+        default=None, description="POS sub-category from Yahoo MA"
+    )
+    conjugation_type: str | None = Field(
+        default=None, description="Conjugation type from Yahoo MA"
+    )
+    conjugation_form: str | None = Field(
+        default=None, description="Conjugation form from Yahoo MA"
     )
 
 
@@ -208,7 +248,13 @@ class Response(BaseModel):
 router = APIRouter()
 
 
-_YAHOO_FURIGANA_URL = "https://jlp.yahooapis.jp/FuriganaService/V2/furigana"
+_YAHOO_MA_URL = "https://jlp.yahooapis.jp/MAService/V2/parse"
+
+# Yahoo MA v2 returns each morpheme as a 7-element positional array:
+#   [surface, reading, base, pos, pos1, conjugation_type, conjugation_form]
+# "*" is used as the null marker for fields that don't apply (e.g. pos1 for
+# verbs, conjugation fields for nouns); we map those to None.
+_MA_NULL = "*"
 
 
 @dataclass(frozen=True)
@@ -225,10 +271,17 @@ class _YahooFetchError:
     error: ErrorInfo
 
 
+def _ma_field(row: list[str], idx: int) -> str | None:
+    if idx >= len(row):
+        return None
+    value = row[idx]
+    return None if value == _MA_NULL else value
+
+
 async def _fetch_yahoo_raw(
     text: str, client: httpx.AsyncClient
 ) -> list[WordResult] | _YahooFetchError:
-    """Call Yahoo Furigana API and parse the response into WordResult tokens.
+    """Call Yahoo MA (Morphological Analysis) API and parse the response.
 
     Returns the token list on success, or a `_YahooFetchError` on any failure
     path. The accent pipeline applies `apply_furigana_overrides` to the raw
@@ -241,14 +294,15 @@ async def _fetch_yahoo_raw(
     data = {
         "id": "1234-1",
         "jsonrpc": "2.0",
-        "method": "jlp.furiganaservice.furigana",
-        "params": {"q": text, "grade": 1},
+        # UniDic variant — uses 助動詞 for ます/たい (vs IPADic's 接尾辞),
+        # which is the linguistic-textbook convention and matches what the
+        # Phase 4 self-check predicates look for.
+        "method": "jlp.maservice.parse.unidic",
+        "params": {"q": text},
     }
 
     try:
-        response = await client.post(
-            _YAHOO_FURIGANA_URL, headers=headers, json=data
-        )
+        response = await client.post(_YAHOO_MA_URL, headers=headers, json=data)
     except httpx.TimeoutException:
         return _YahooFetchError(
             status=408,
@@ -273,7 +327,7 @@ async def _fetch_yahoo_raw(
         )
 
     payload = response.json()
-    if "result" not in payload or "word" not in payload["result"]:
+    if "result" not in payload or "tokens" not in payload["result"]:
         return _YahooFetchError(
             status=500,
             error=ErrorInfo(
@@ -282,26 +336,22 @@ async def _fetch_yahoo_raw(
         )
 
     parsed: list[WordResult] = []
-    for word in payload["result"]["word"]:
-        if "subword" in word:
-            subword_list = [
-                WordResult(furigana=sub["furigana"], surface=sub["surface"])
-                for sub in word["subword"]
-            ]
-            parsed.append(
-                WordResult(
-                    surface=word["surface"],
-                    furigana=word["furigana"],
-                    subword=subword_list,
-                )
+    for row in payload["result"]["tokens"]:
+        if not isinstance(row, list) or len(row) < 2:
+            continue
+        surface = row[0]
+        reading = row[1] or surface
+        parsed.append(
+            WordResult(
+                surface=surface,
+                furigana=reading,
+                base=_ma_field(row, 2),
+                pos=_ma_field(row, 3),
+                pos1=_ma_field(row, 4),
+                conjugation_type=_ma_field(row, 5),
+                conjugation_form=_ma_field(row, 6),
             )
-        else:
-            parsed.append(
-                WordResult(
-                    surface=word["surface"],
-                    furigana=word.get("furigana", word["surface"]),
-                )
-            )
+        )
     return parsed
 
 
@@ -517,6 +567,16 @@ def _build_word_result(token: Any, ojad_span: list[dict[str, Any]]) -> WordAccen
         if token.subword
         else []
     )
+    # Carry MA's POS metadata through alignment so downstream patches can
+    # branch on it. Tokens constructed by override replacements (no MA
+    # backing) will have these as None — that's fine.
+    pos_meta = {
+        "base": getattr(token, "base", None),
+        "pos": getattr(token, "pos", None),
+        "pos1": getattr(token, "pos1", None),
+        "conjugation_type": getattr(token, "conjugation_type", None),
+        "conjugation_form": getattr(token, "conjugation_form", None),
+    }
 
     if not ojad_span:
         # k=0 path: emit type-0 fallback so the downstream override pass and
@@ -532,6 +592,7 @@ def _build_word_result(token: Any, ojad_span: list[dict[str, Any]]) -> WordAccen
                 )
             ],
             subword=subword,
+            **pos_meta,
         )
 
     # Drop OJAD entries with empty text (phrase-boundary sentinels). They
@@ -549,6 +610,7 @@ def _build_word_result(token: Any, ojad_span: list[dict[str, Any]]) -> WordAccen
                 )
             ],
             subword=subword,
+            **pos_meta,
         )
     accents = [
         AccentInfo(
@@ -567,6 +629,7 @@ def _build_word_result(token: Any, ojad_span: list[dict[str, Any]]) -> WordAccen
         furigana=display,
         accent=accents,
         subword=subword,
+        **pos_meta,
     )
 
 
@@ -809,6 +872,10 @@ async def _process_accent_chunk(
 
         final_results = await align_accent(furigana_results, ojad_results)
         final_results = apply_accent_overrides(final_results)
+        # POS-driven suffix patches run after the full-span overrides so
+        # that tokens replaced by overrides (pos=None) are skipped by the
+        # patch predicates.
+        final_results = apply_accent_patches(final_results)
         final_results = _restore_urls(final_results, urls)
 
         return Response(status=200, result=final_results)

--- a/api/reading_overrides.py
+++ b/api/reading_overrides.py
@@ -23,8 +23,8 @@ from __future__ import annotations
 
 import logging
 import re
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Callable, TypeVar
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 if TYPE_CHECKING:
     from api.accent_marker import WordAccentResult, WordResult
@@ -60,6 +60,13 @@ class FuriganaOverride:
     pattern: re.Pattern[str]
     replacements: tuple[ReplacementToken, ...]
     description: str = ""
+    # When set, the regex match is additionally filtered: only fires if
+    # `pos_match(tokens_in_match_span)` returns True. None preserves the
+    # original surface-only matching used by every existing override. The
+    # span is `list[WordResult]` for furigana overrides, `list[WordAccentResult]`
+    # for accent overrides — both expose the same POS attributes after the
+    # Yahoo MA migration.
+    pos_match: Callable[[list[Any]], bool] | None = field(default=None)
 
 
 # accent_marking_type values (mirror AccentInfo)
@@ -404,6 +411,20 @@ def _apply(
         if start_idx < cursor:
             # earlier non-overlapping match already consumed this region
             continue
+        if m.override.pos_match is not None:
+            token_span = list(words[start_idx:end_idx])
+            if not m.override.pos_match(token_span):
+                # POS check rejected — pretend this match never happened.
+                # Earlier-start, lower-priority matches (already filtered
+                # out by _collect_matches) don't get a second chance, but
+                # subsequent non-overlapping matches still do.
+                logger.debug(
+                    "Override %r matched at [%d, %d) but pos_match rejected",
+                    m.override.description or m.override.pattern.pattern,
+                    m.start,
+                    m.end,
+                )
+                continue
         while cursor < start_idx:
             out.append(words[cursor])
             cursor += 1
@@ -468,3 +489,135 @@ def apply_accent_overrides(
         )
 
     return _apply(words, lambda w: w.surface, build)
+
+
+# ---------- POS-driven in-place accent patches ----------
+#
+# Distinct from `apply_accent_overrides` above (which does full-span
+# replacement). Each rule inspects a single token's MA-provided POS metadata
+# (`pos`, `pos1`, `base`, `conjugation_form`) and may rewrite its trailing
+# accent — without touching the verb stem on the previous token.
+#
+# Rules are defined as functions to `WordAccentResult → WordAccentResult |
+# None`. Returning None means "no change"; returning a new object swaps the
+# token in place. The patch pipeline is small enough that we don't bother
+# with a generic rule-table indirection.
+
+
+# Empty initial set — the Phase 1 spike found zero false-positive cases
+# where MA mis-tags a 五段動詞 as 接尾辞. Populate as real cases arrive.
+_PATCH_EXCEPTIONS: frozenset[str] = frozenset()
+
+
+# Conjugation forms where the first-mora FALL rule applies. Polite ます
+# behaves like an atamadaka 2-mora foot in 終止形 (ます → ま↓す) and in
+# 連用形 (まし[た] → ま↓し-た). It does NOT apply in 未然形 — in ません,
+# the kernel falls on せ before the final ん, not on ま. OJAD already
+# predicts ません correctly, and our patch would un-fix it.
+_FIRST_MORA_FALL_FORMS = ("終止形", "連用形")
+
+
+def _patches_first_mora(conjugation_form: str | None) -> bool:
+    if not conjugation_form:
+        return False
+    return any(conjugation_form.startswith(p) for p in _FIRST_MORA_FALL_FORMS)
+
+
+def _is_masu_auxiliary(token: WordAccentResult) -> bool:
+    """Self-check: pos × conjugation_type × base × surface × conjugation_form.
+
+    Yahoo MA (UniDic) tags polite-form ます as pos=助動詞 with
+    conjugation_type=助動詞-マス and base=ます (regardless of which
+    conjugated form: ます / まし / ませ all share base=ます). The
+    conjugation_form check narrows the patch to forms where the kernel
+    really is on the first mora — see `_FIRST_MORA_FALL_FORMS` above.
+
+    Failure modes filtered out:
+    - 五段動詞 励ます: pos=動詞 → fails first axis.
+    - UniDic-mistagged 升 (surname, reading=ます): surface=升 (kanji)
+      doesn't start with ま → fails surface prefix.
+    - ませ in ません (cform=未然形-一般): rejected by _patches_first_mora.
+    """
+    if token.surface in _PATCH_EXCEPTIONS:
+        return False
+    return (
+        token.pos == "助動詞"
+        and token.conjugation_type == "助動詞-マス"
+        and token.base == "ます"
+        and token.surface.startswith("ま")
+        and token.furigana.startswith("ま")
+        and _patches_first_mora(token.conjugation_form)
+    )
+
+
+def _is_tai_auxiliary(token: WordAccentResult) -> bool:
+    """Self-check for the desiderative たい suffix.
+
+    UniDic tags たい / たく / たかった with pos=助動詞,
+    conjugation_type=助動詞-タイ, base=たい. All known conjugations have
+    the kernel on the first mora (た), so the conjugation_form gate
+    accepts all 終止形 / 連用形 variants.
+    """
+    if token.surface in _PATCH_EXCEPTIONS:
+        return False
+    return (
+        token.pos == "助動詞"
+        and token.conjugation_type == "助動詞-タイ"
+        and token.base == "たい"
+        and token.surface.startswith("た")
+        and token.furigana.startswith("た")
+        and _patches_first_mora(token.conjugation_form)
+    )
+
+
+def _patch_first_mora_fall(token: WordAccentResult) -> WordAccentResult:
+    """Return a copy of `token` with accent[0]=FALL, accent[1:]=HEIBAN.
+
+    Mirrors the rule "for ます/たい-family suffixes the accent kernel sits
+    on the first mora": the high pitch of the verb stem drops as soon as
+    the suffix begins, and the rest of the suffix stays low.
+    """
+    from api.accent_marker import AccentInfo, WordAccentResult as _WordAccentResult
+
+    if not token.accent:
+        return token
+    new_accent: list[AccentInfo] = []
+    for i, a in enumerate(token.accent):
+        marking = _FALL if i == 0 else _HEIBAN
+        new_accent.append(
+            AccentInfo(
+                furigana=a.furigana,
+                accent_marking_type=marking,
+                length=a.length,
+            )
+        )
+    return _WordAccentResult(
+        surface=token.surface,
+        furigana=token.furigana,
+        accent=new_accent,
+        subword=token.subword,
+        base=token.base,
+        pos=token.pos,
+        pos1=token.pos1,
+        conjugation_type=token.conjugation_type,
+        conjugation_form=token.conjugation_form,
+    )
+
+
+def apply_accent_patches(
+    words: list[WordAccentResult],
+) -> list[WordAccentResult]:
+    """POS-driven in-place accent patches on aligned MA tokens.
+
+    Idempotent — applying the same patch twice yields the same output. Safe
+    to run after `apply_accent_overrides`: tokens that were entirely
+    replaced by an override have `pos=None`/`base=None` and the self-check
+    predicates therefore reject them.
+    """
+    out: list[WordAccentResult] = []
+    for token in words:
+        if _is_masu_auxiliary(token) or _is_tai_auxiliary(token):
+            out.append(_patch_first_mora_fall(token))
+        else:
+            out.append(token)
+    return out


### PR DESCRIPTION
### 目的
Closes #48. PR #47 用 regex-on-surface 處理日期 / 期間 / 年齡 等 closed-class case。本 PR 把 Yahoo Furigana v2 換成 Yahoo MA v2 (UniDic 變體)，把 POS 資訊接到 pipeline 上，然後新增一層「**in-place 詞尾 patch**」處理動詞ます型與たい形容詞型的 ま / た 下降。

> Base = `feat/reading-overrides` (PR #47)。等 #47 merge 後改 base 到 `main`。

### 方法／實作說明

#### Phase 1 — Spike (已完成，code 已刪除)
寫了一支 `scripts/spike_ma_vs_furigana.py`（throwaway，已在 commit 前刪掉）比對 MA-IPADic / MA-UniDic / Furigana 三者：
- **Surface concat parity**：test_0.txt (36 行) / test_1.txt (57 行) 兩邊 100% match
- **Override boundary check**：10 個觸發既有 override 的句子全部 hit on MA tokens
- **POS disambiguation probe**：13 句邊界 case 全部分類正確（食べます ↔ 励ます、升 名詞 ↔ ます 助動詞、ません 拆成 [ませ, ん]、たかった / たくない 不同活用）

#### Phase 2 — Furigana → MA-UniDic 遷移
- `api/accent_marker.py`：
  - `_YAHOO_FURIGANA_URL` → `_YAHOO_MA_URL = "https://jlp.yahooapis.jp/MAService/V2/parse"`
  - `method` 從 `jlp.furiganaservice.furigana` 改成 `jlp.maservice.parse.unidic`
  - 解析新的 positional array response：`[surface, reading, base, pos, pos1, conjugation_type, conjugation_form]`，`*` null marker 對應到 Python `None`
- `WordResult` / `WordAccentResult` 加 5 個 Optional POS 欄位（`base` / `pos` / `pos1` / `conjugation_type` / `conjugation_form`）— 全部預設 `None`，override-constructed token（沒有 MA backing）能無痛維持向後相容
- `_build_word_result` 把 POS metadata 從 input token 透過 `**pos_meta` unpacking 帶到 alignment 輸出

**為何用 UniDic 不用 IPADic**：兩者 7-field schema 完全一樣，但 UniDic 把 ます/たい 標成 `pos=助動詞` + `conjugation_type=助動詞-マス/-タイ`，IPADic 標成 `pos=接尾辞` + `pos1=動詞性接尾辞`。`助動詞` 是教科書級的標準分類，linguistics 文獻通用；`conjugation_type=助動詞-マス` 提供一個獨立第二軸給 self-check。唯一已知 regression 是 UniDic 把 `升` mis-tag 成「固有名詞-人名-姓」(reading=ます)；不影響我們的 patch（surface=升 漢字，failing the surface prefix check），但 `升` 單獨出現時讀音會顯示成 ます 而非 IPADic 的 しょう。低頻名詞，未來如需要可加 regex override 修正。

#### Phase 3 — Override engine 加 POS predicate（基礎建設）
`FuriganaOverride` 加 `pos_match: Callable[[list[Any]], bool] | None`。在 `_apply` 內 boundary-resolve 之後做 filter，`pos_match=None` 保留原本純 regex 行為。本 PR 沒新增任何用到 `pos_match` 的 override — 純基礎建設，留給未來 case（e.g. `升` 視 POS 決定發音）使用。

#### Phase 4 — `apply_accent_patches`（核心 feature）
新增 in-place patch pass，跟 `apply_accent_overrides` 的 full-span replacement 分離：

```python
def apply_accent_patches(words: list[WordAccentResult]) -> list[WordAccentResult]:
    """POS-driven in-place accent patches on aligned MA tokens."""
```

呼叫順序：`align_accent` → `apply_accent_overrides`（既有 full-span overrides）→ `apply_accent_patches`（新的 POS patches）→ `_restore_urls`。

**Self-check 五軸**（任何一軸 mis-tag 都不會 fire）：
1. `pos == "助動詞"`（過濾 `励ます` 等 `pos=動詞`）
2. `conjugation_type == "助動詞-マス"` / `"助動詞-タイ"`（區分 ます 跟 助動詞-ヌ 等其他助動詞）
3. `base == "ます"` / `"たい"`
4. `surface.startswith("ま")` / `"た"`（過濾 UniDic 把 `升` mis-tag 成人名・reading=ます 的 case — surface 是漢字「升」）
5. `conjugation_form ∈ {終止形*, 連用形*}`（**load-bearing**：`ません` 的 `ませ` 是 `cform=未然形-一般`，kernel 自然落在 せ 而非 ま，OJAD 已預測正確；少了這層 gate 就會把對的 ません 弄壞）

**Patch 內容**：first mora = FALL，其餘 = HEIBAN。透過 `base` 跨活用形不變的性質，**一條規則涵蓋多種變體**：ます / まし / たい / たく / たかっ 共用同個 helper。

`_PATCH_EXCEPTIONS: frozenset[str]` 是 exception list 的 escape hatch — 初始為空（spike 沒找到任何 MA mis-tag），留給未來實際 case 出現再 populate。

### 驗證結果（11 句 disambiguation probe，全 pass）

| 輸入 | Token | 預期 | 實際 |
|---|---|---|---|
| 飲み**ます** | ます (終止形) | ま↓す | ま=2, す=1 ✓ |
| 食べ**たい** | たい (終止形) | た↓い | た=2, い=1 ✓ |
| 見**ました** | まし (連用形) | ま↓し | ま=2, し=1 ✓ |
| 行き**ません** | ませ (未然形) | ま-↓せ-ん | ま=1, **せ=2** ✓ (patch SKIPPED — gate 生效) |
| 食べ**ませんでした** | ませ + でし + た | ま-せ-ん で し た | 同上 ✓ |
| 彼を**励ます** | 励ます (動詞 one token) | 既有 OJAD 預測 | 不 patch ✓ |
| **升**は容器です | 升 (名詞) | 不 patch | 不 patch ✓ |
| 怠け**たかった** | たかっ (連用形-促音便) | た↓か っ | た=2, か=1, っ=1 ✓ |
| 泣き**たくない** | たく (連用形) | た↓く | た=2, く=1 ✓ |
| 3月5日(土)、7日間と1日 | (regression) | byte-identical to #47 | ✓ |
| 彼女は20歳です | (regression) | byte-identical to #47 | ✓ |

### Diff 範圍
- `api/accent_marker.py` — Furigana→MA endpoint 切換、`WordResult` + `WordAccentResult` 加 5 個 Optional 欄位、`_build_word_result` 透傳 POS metadata、`_process_accent_chunk` 接 `apply_accent_patches`
- `api/reading_overrides.py` — `FuriganaOverride.pos_match`、`_apply` filter logic、新增 `apply_accent_patches` 與 self-check predicates

### Out of scope（留給後續 issue / PR）
- **i-adjective た形** 跨 stem + 助動詞 的多 token 規則（高かった = 高 + かっ + た），需要不同的多 token matcher
- **Loanword 3-mora 規則**（バナナ / ピアノ 系列）
- **数詞 + counter 不規則**（4時 / 7時 / 9時 / 1分 / 1人 / 2人）— 屬於 regex-side，跟本 PR 的 POS-side 分離；之後做應該另開 PR
- **升 → しょう 名詞 reading override** — UniDic 把 升 mis-tag 成人名的 side-effect

### 附註
- POS predicate (Phase 3) 是基礎建設，本 PR 沒新增 user，純為未來 case 準備。判斷標準：用 regex 表達不到的 case 出現再加；現在堆 `升`→`しょう` 之類的 POS-aware override 算 premature。
- 把 spike script 在 commit 前刪掉了，但 spike 過程的設計決策（用 UniDic、`conjugation_form` 當第三 axis、初始 exception list 空）都寫在 docstring + commit message 裡。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
