### PR TITLE
fix(accent): degrade gracefully when OJAD is unavailable

### DIFF
--- a/api/accent/models.py
+++ b/api/accent/models.py
@@ -111,3 +111,8 @@ class AccentResponse(BaseModel):
         default=None,
         description="An object that describes the details of an error when one occurs",
     )
+    warning: str | None = Field(
+        default=None,
+        description="A non-fatal warning when results are degraded, e.g. furigana "
+        "returned without pitch accent because OJAD was unavailable",
+    )

--- a/api/accent/ojad.py
+++ b/api/accent/ojad.py
@@ -23,6 +23,20 @@ logger = logging.getLogger("api")
 
 OJAD_URL = "https://www.gavo.t.u-tokyo.ac.jp/ojad/phrasing/index"
 
+# Per-request timeout for the OJAD POST. Overrides the global client timeout so a
+# down / unresponsive OJAD fails fast (≈2s on a dead host) instead of hanging for
+# the full global 10s before the pipeline can degrade gracefully.
+OJAD_TIMEOUT = httpx.Timeout(5.0, connect=2.0)
+
+
+class OJADUnavailableError(Exception):
+    """OJAD could not be reached or returned an error.
+
+    Raised on any transport failure (connect / read timeout, connection
+    refused) or non-2xx status. Callers should treat this as "no pitch
+    contour available" and degrade rather than fail the whole request.
+    """
+
 
 async def get_ojad_result(
     query_text: str,
@@ -47,12 +61,14 @@ async def get_ojad_result(
 
     # Send a POST and receive the website html code
     try:
-        response = await client.post(OJAD_URL, data=data)
+        response = await client.post(OJAD_URL, data=data, timeout=OJAD_TIMEOUT)
         response.raise_for_status()
         logger.debug(f"[OJAD] Status Code: {response.status_code}")
-    except Exception:
-        logger.exception("[OJAD] Request Failed")
-        raise
+    except httpx.HTTPError as e:
+        # Covers ConnectTimeout / ReadTimeout / ConnectError as well as the
+        # HTTPStatusError from raise_for_status() — all httpx.HTTPError subclasses.
+        logger.warning(f"[OJAD] Unavailable: {e}")
+        raise OJADUnavailableError(str(e)) from e
 
     website = response.text
 

--- a/api/accent/pipeline.py
+++ b/api/accent/pipeline.py
@@ -18,7 +18,7 @@ import neologdn
 from api.accent.align import align_accent
 from api.accent.furigana import fetch_furigana
 from api.accent.models import AccentResponse, ErrorInfo
-from api.accent.ojad import get_ojad_result
+from api.accent.ojad import OJADUnavailableError, get_ojad_result
 
 logger = logging.getLogger("api")
 
@@ -42,11 +42,24 @@ async def process_accent_chunk(text: str, client: httpx.AsyncClient) -> AccentRe
         furigana_results = furigana_response.result
         logger.debug(f"Yahoo Results Count: {len(furigana_results)}")
 
-        _ojad_surface, ojad_results = await get_ojad_result(query_text, client)
+        # OJAD only enriches the result with pitch accent. If it is down, fall
+        # back to furigana-only output (align_accent emits accent_marking_type=0
+        # for every mora when given an empty list) rather than failing the
+        # request — see api/accent/align.py "MATCH FAILED" branch.
+        warning = None
+        try:
+            _ojad_surface, ojad_results = await get_ojad_result(query_text, client)
+        except OJADUnavailableError as e:
+            logger.warning(f"OJAD unavailable, degrading to furigana-only: {e}")
+            ojad_results = []
+            warning = (
+                "OJAD pitch-accent service is unavailable; "
+                "returning furigana without pitch accent."
+            )
 
         final_results = await align_accent(furigana_results, ojad_results)
 
-        return AccentResponse(status=200, result=final_results)
+        return AccentResponse(status=200, result=final_results, warning=warning)
 
     except Exception as e:
         logger.exception(f"Unexpected error occurred: {text}")


### PR DESCRIPTION
## Problem

OJAD (`www.gavo.t.u-tokyo.ac.jp`) is currently globally unreachable (80/443 TCP connect timing out, ping 100% loss — confirmed from an independent external egress, not an IP block). Because every accent chunk POSTs to OJAD for the per-mora pitch contour, an OJAD outage made `/MarkAccent/`:

1. Hang for the **full global 10s timeout** (`main.py` `httpx.AsyncClient(timeout=10.0)`).
2. Re-raise the `httpx.ConnectTimeout` from `get_ojad_result` (`except Exception: raise`).
3. Surface as **HTTP 500** via the pipeline's broad catch.

So users waited ~10s only to get a 500. Prod logs showed ~1898 `ConnectTimeout` / 1387 `[OJAD] Request Failed` in 24h.

## Fix

Pitch accent from OJAD only *enriches* the furigana result, so an OJAD outage should degrade — not fail — the request.

- **`api/accent/ojad.py`** — Add a short per-request timeout `OJAD_TIMEOUT = httpx.Timeout(5.0, connect=2.0)` so a down OJAD fails fast (~2s) instead of hanging on the global 10s. Replace `except Exception: raise` with `except httpx.HTTPError` (covers connect/read timeouts, connection errors, and `raise_for_status()`'s status errors) → log a warning and raise a dedicated `OJADUnavailableError`.
- **`api/accent/pipeline.py`** — Catch `OJADUnavailableError`, set `ojad_results = []` plus a warning, and continue. `align_accent` already emits `accent_marking_type=0` for an empty OJAD list (its "MATCH FAILED" branch), so this yields furigana-only output at **status 200**. The broad `except → 500` stays as a last-resort guard.
- **`api/accent/models.py`** — Add an optional, backward-compatible `warning` field to `AccentResponse` for degraded results.

## Verification

- `uv run ruff check api/accent/` and `uv run mypy api/accent/` — both clean.
- **OJAD-down simulation** (mocked `ConnectTimeout`): `get_ojad_result` raises `OJADUnavailableError`, the short timeout is passed through, and the pipeline returns `status=200`, warning set, all `accent_marking_type==0`, furigana preserved. No 500, no 10s hang.
- **Happy path** (OJAD reachable): `status=200`, `warning=null`, real pitch contour preserved — no regression.

Close #59 