### PR TITLE
ci(cd): build multi-arch images (amd64 + arm64)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,7 +59,8 @@ jobs:
         with:
           context: .
           file: ./Dockerfile          # adjust if the api-tools Dockerfile path differs
-          platforms: linux/amd64
+          # amd64 + arm64 so images run natively on the arm64 deploy host
+          platforms: linux/amd64,linux/arm64
           push: true
           provenance: true
           sbom: true


### PR DESCRIPTION
### 目的

Publish arm64 images alongside amd64 so the service runs natively on the arm64 (Oracle Ampere) deploy host. Images are amd64-only today.

### 方法／實作說明

Add `linux/arm64` to the build-push `platforms` in the CD workflow. QEMU and Buildx are already configured, so the published tags (`:stable` / `:dev` / semver / `sha-*`) become multi-arch manifest lists.

- 主要修改：
  - `.github/workflows/cd.yml`
- 關鍵實作：
  - Multi-platform buildx build via `docker/build-push-action` (`provenance` / `sbom` unchanged).

### 關聯 Issue

Closes #65.

### 附註

arm64 builds run under QEMU (fugashi build + UniDic download), so CD will be noticeably slower.
